### PR TITLE
회원가입 요청 api에 선호 카테고리 추가 (MOKA-48)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/domain/PreferenceCategory.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/domain/PreferenceCategory.java
@@ -24,6 +24,7 @@ public class PreferenceCategory extends BaseEntity {
     private User user;
 
     @Column(name = "category_name", nullable = false, length = 20)
+    @Enumerated(value = EnumType.STRING)
     private Category category;
 
     public PreferenceCategory(User user, Category category) {

--- a/src/main/java/com/mokaform/mokaformserver/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/dto/request/SignupRequest.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -28,15 +30,20 @@ public class SignupRequest {
     @NotBlank
     private String job;
 
+    @NotEmpty
+    private List<String> category;
+
     @Builder
     public SignupRequest(String email, String password,
                          String nickname, String ageGroup,
-                         String gender, String job) {
+                         String gender, String job,
+                         List<String> category) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.ageGroup = ageGroup;
         this.gender = gender;
         this.job = job;
+        this.category = category;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/PreferenceCategoryRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/PreferenceCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.mokaform.mokaformserver.user.repository;
+
+import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PreferenceCategoryRepository extends JpaRepository<PreferenceCategory, Long> {
+}

--- a/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
@@ -1,10 +1,13 @@
 package com.mokaform.mokaformserver.user.service;
 
+import com.mokaform.mokaformserver.survey.domain.enums.Category;
+import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
 import com.mokaform.mokaformserver.user.domain.User;
 import com.mokaform.mokaformserver.user.domain.enums.AgeGroup;
 import com.mokaform.mokaformserver.user.domain.enums.Gender;
 import com.mokaform.mokaformserver.user.domain.enums.Job;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
+import com.mokaform.mokaformserver.user.repository.PreferenceCategoryRepository;
 import com.mokaform.mokaformserver.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -13,10 +16,13 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PreferenceCategoryRepository preferenceCategoryRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository, PreferenceCategoryRepository preferenceCategoryRepository,
+                       PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
+        this.preferenceCategoryRepository = preferenceCategoryRepository;
         this.passwordEncoder = passwordEncoder;
     }
 
@@ -29,7 +35,14 @@ public class UserService {
                 .gender(Gender.valueOf(request.getGender()))
                 .job(Job.valueOf(request.getJob()))
                 .build();
-
         userRepository.save(user);
+
+        request.getCategory()
+                .forEach(v -> createPreferenceCategory(user, v));
+    }
+
+    private void createPreferenceCategory(User user, String categoryValue) {
+        PreferenceCategory preferenceCategory = new PreferenceCategory(user, Category.valueOf(categoryValue));
+        preferenceCategoryRepository.save(preferenceCategory);
     }
 }


### PR DESCRIPTION
## 회원가입 요청 api에 선호 카테고리 추가 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-48

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 회원가입 request DTO에 선호 카테고리 추가
- 회원가입 시, preference_category 테이블에 선호 카테고리가 저장되도록 추가

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
**예시**
_실행 전에 설정파일 확인하세요~!_
- postman에서 아래와 같이 입력
<img width="1283" alt="스크린샷 2022-10-11 오전 11 13 31" src="https://user-images.githubusercontent.com/53249897/194981791-c00025bd-0fe4-43c8-a1af-a9b371dea846.png">

```json
{
    "email": "test1@gmail.com",
    "password": "test123!!",
    "nickname": "testNick",
    "ageGroup": "TWENTIES",
    "gender": "MALE",
    "job": "OFFICE_WORKERS",
    "category": [
        "HOBBY",
        "SOCIAL_POLITICS",
        "LEARNING"
        ]
}
```

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] vaildation 추가
- [ ] 테스트 코드 추가