### PR TITLE
feat: Survey에 summary column 추가

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
@@ -31,6 +31,9 @@ public class Survey extends BaseEntity {
     @Column(name = "title", nullable = false, length = 50)
     private String title;
 
+    @Column(name = "summary", nullable = false)
+    private String summary;
+
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
@@ -54,10 +57,11 @@ public class Survey extends BaseEntity {
 
     @Builder
     public Survey(User user, String title,
-                  LocalDate startDate, LocalDate endDate,
+                  String summary, LocalDate startDate, LocalDate endDate,
                   Boolean isAnonymous, Boolean isPublic) {
         this.user = user;
         this.title = title;
+        this.summary = summary;
         this.startDate = startDate;
         this.endDate = endDate;
         this.isAnonymous = isAnonymous;

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/request/SurveyCreateRequest.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/request/SurveyCreateRequest.java
@@ -19,6 +19,9 @@ public class SurveyCreateRequest {
     @NotBlank
     private String title;
 
+    @NotBlank
+    private String summary;
+
     @NotNull
     private Boolean isAnonymous;
 
@@ -38,11 +41,12 @@ public class SurveyCreateRequest {
     private List<MultiQuestion> multiQuestions;
 
     @Builder
-    public SurveyCreateRequest(String title, LocalDate startDate,
-                               LocalDate endDate, Boolean isAnonymous,
-                               Boolean isPublic, List<Question> questions,
-                               List<MultiQuestion> multiQuestions) {
+    public SurveyCreateRequest(String title, String summary,
+                               LocalDate startDate, LocalDate endDate,
+                               Boolean isAnonymous, Boolean isPublic,
+                               List<Question> questions, List<MultiQuestion> multiQuestions) {
         this.title = title;
+        this.summary = summary;
         this.startDate = startDate;
         this.endDate = endDate;
         this.isAnonymous = isAnonymous;

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -31,6 +31,7 @@ public class SurveyService {
         Survey savedSurvey = saveSurvey(Survey.builder()
                 .user(user)
                 .title(request.getTitle())
+                .summary(request.getSummary())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
                 .isAnonymous(request.getIsAnonymous())


### PR DESCRIPTION
## Survey에 summary column 추가 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
없음

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- Survey에 summary column 추가
- SurveyCreateRequest DTO에 summary 필드 추가 

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
- client에서 설문 생성 요청할 때 summary 추가되었는지 확인해주세요
- API 명세는 swagger로 확인 부탁드립니다

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->