### PR TITLE
설문 공유키 생성 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // swagger (SpringDoc)
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+
+    // apache commons lang3
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
@@ -6,12 +6,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Entity
 @Table(name = "survey")
@@ -66,7 +66,7 @@ public class Survey extends BaseEntity {
         this.endDate = endDate;
         this.isAnonymous = isAnonymous;
         this.isPublic = isPublic;
-        this.sharing_key = UUID.randomUUID().toString();
+        this.sharing_key = RandomStringUtils.random(10, true, true);
         this.isDeleted = false;
     }
 }


### PR DESCRIPTION
## 설문 공유키 생성 로직 수정 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
없음

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- apache commons lang3 의존성 추가
- sharing key 생성을 UUID에서 10글자 랜덤 스트링으로 변경
  - 알파벳 대문자, 알파벳 소문자, 숫자로 구성된 10자 문자열 생성

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
- 랜덤 문자열을 10자로 하는 것 괜찮나요?
