### PR TITLE
feat: 답변 저장 구현

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/answer/controller/AnswerController.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/controller/AnswerController.java
@@ -1,0 +1,52 @@
+package com.mokaform.mokaformserver.answer.controller;
+
+import com.mokaform.mokaformserver.answer.dto.request.AnswerCreateRequest;
+import com.mokaform.mokaformserver.answer.service.AnswerService;
+import com.mokaform.mokaformserver.common.exception.ApiException;
+import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
+import com.mokaform.mokaformserver.common.response.ApiResponse;
+import com.mokaform.mokaformserver.survey.repository.QuestionRepository;
+import com.mokaform.mokaformserver.user.domain.User;
+import com.mokaform.mokaformserver.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/answer")
+public class AnswerController {
+    private final AnswerService answerCreateService;
+    private final UserRepository userRepository;
+
+    private final QuestionRepository questionRepository;
+
+    public AnswerController(AnswerService answerCreateService, UserRepository userRepository,
+                            QuestionRepository questionRepository) {
+        this.answerCreateService = answerCreateService;
+        this.userRepository = userRepository;
+        this.questionRepository = questionRepository;
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> createAnswer(@RequestBody @Valid AnswerCreateRequest request,
+                                                    @RequestParam Long userId) {
+        // TODO: 로그인 구현 후에 삭제
+        User user = getUser(userId);
+
+        answerCreateService.createAnswer(request, user);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("새로운 답변 생성이 성공하였습니다.")
+                        .build());
+
+    }
+
+    // TODO: 로그인 구현 후에 삭제
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() ->
+                        new ApiException(CommonErrorCode.INVALID_PARAMETER));
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/domain/Answer.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/domain/Answer.java
@@ -1,0 +1,38 @@
+package com.mokaform.mokaformserver.answer.domain;
+
+import com.mokaform.mokaformserver.common.entitiy.BaseEntity;
+import com.mokaform.mokaformserver.survey.domain.Question;
+import com.mokaform.mokaformserver.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Answer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "answer_id")
+    private Long answerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "surveyee_id", referencedColumnName = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", referencedColumnName = "question_id", nullable = false)
+    private Question question;
+
+    @Builder
+    public Answer(User user, Question question) {
+        this.user = user;
+        this.question = question;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/domain/EssayAnswer.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/domain/EssayAnswer.java
@@ -1,0 +1,34 @@
+package com.mokaform.mokaformserver.answer.domain;
+
+import com.mokaform.mokaformserver.common.entitiy.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "essay_answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class EssayAnswer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "essay_answer_id")
+    private Long essayAnswerId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id", referencedColumnName = "answer_id", nullable = false)
+    private Answer answer;
+
+    @Column(name = "answer_content", nullable = false, length = 255)
+    private String answerContent;
+
+    @Builder
+    public EssayAnswer(Answer answer, String answerContent) {
+        this.answer = answer;
+        this.answerContent = answerContent;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/domain/MultipleChoiceAnswer.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/domain/MultipleChoiceAnswer.java
@@ -1,0 +1,35 @@
+package com.mokaform.mokaformserver.answer.domain;
+
+import com.mokaform.mokaformserver.common.entitiy.BaseEntity;
+import com.mokaform.mokaformserver.survey.domain.MultipleChoiceQuestion;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "multiple_choice_answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MultipleChoiceAnswer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "multiple_choice_answer_id")
+    private Long multipleChoiceAnswerId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id", referencedColumnName = "answer_id", nullable = false)
+    private Answer answer;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "multi_question_id", referencedColumnName = "multi_question_id", nullable = false)
+    private MultipleChoiceQuestion multipleChoiceQuestion;
+
+    @Builder
+    public MultipleChoiceAnswer(Answer answer, MultipleChoiceQuestion multipleChoiceQuestion) {
+        this.answer = answer;
+        this.multipleChoiceQuestion = multipleChoiceQuestion;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/domain/OXAnswer.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/domain/OXAnswer.java
@@ -1,0 +1,33 @@
+package com.mokaform.mokaformserver.answer.domain;
+
+import com.mokaform.mokaformserver.common.entitiy.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "ox_answer")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OXAnswer extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ox_answer_id")
+    private Long oxAnswerId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "answer_id", referencedColumnName = "answer_id", nullable = false)
+    private Answer answer;
+
+    @Column(name = "is_yes", nullable = false)
+    private Boolean isYes;
+
+    @Builder
+    public OXAnswer(Answer answer, Boolean isYes) {
+        this.answer = answer;
+        this.isYes = isYes;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/request/AnswerCreateRequest.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/request/AnswerCreateRequest.java
@@ -1,0 +1,73 @@
+package com.mokaform.mokaformserver.answer.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class AnswerCreateRequest {
+    private List<EssayAnswer> essayAnswers;
+
+    private List<MultipleChoiceAnswer> multipleChoiceAnswers;
+
+    private List<OXAnswer> oxAnswers;
+
+    @Builder
+    public  AnswerCreateRequest(List<EssayAnswer> essayAnswers, List<MultipleChoiceAnswer> multipleChoiceAnswers, List<OXAnswer> oxAnswers) {
+        this.essayAnswers = essayAnswers;
+        this.multipleChoiceAnswers = multipleChoiceAnswers;
+        this.oxAnswers = oxAnswers;
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class EssayAnswer {
+        @NotNull
+        private Long questionId;
+        @NotBlank
+        private String answerContent;
+
+        @Builder
+        public EssayAnswer(Long questionId, String answerContent) {
+            this.questionId = questionId;
+            this.answerContent = answerContent;
+        }
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class MultipleChoiceAnswer {
+        @NotNull
+        private Long questionId;
+
+        @NotNull
+        private Long multiQuestionId;
+
+        @Builder
+        public MultipleChoiceAnswer(Long questionId, Long multiQuestionId) {
+            this.multiQuestionId = multiQuestionId;
+            this.questionId = questionId;
+        }
+    }
+
+    @NoArgsConstructor
+    @Getter
+    public static class OXAnswer {
+        @NotNull
+        private Long questionId;
+        @NotNull
+        private Boolean isYes;
+
+        @Builder
+        public OXAnswer(Long questionId, Boolean isYes) {
+            this.questionId = questionId;
+            this.isYes = isYes;
+        }
+    }
+
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerCreateResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerCreateResponse.java
@@ -1,0 +1,10 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+public class AnswerCreateResponse {
+
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.domain.Answer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/EssayAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/EssayAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.domain.EssayAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long> {
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/MultipleChoiceAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/MultipleChoiceAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.domain.MultipleChoiceAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MultipleChoiceAnswerRepository extends JpaRepository<MultipleChoiceAnswer, Long> {
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/OXAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/OXAnswerRepository.java
@@ -1,0 +1,7 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.domain.OXAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OXAnswerRepository extends JpaRepository<OXAnswer, Long> {
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
@@ -1,0 +1,127 @@
+package com.mokaform.mokaformserver.answer.service;
+
+import com.mokaform.mokaformserver.answer.domain.Answer;
+import com.mokaform.mokaformserver.answer.domain.EssayAnswer;
+import com.mokaform.mokaformserver.answer.domain.MultipleChoiceAnswer;
+import com.mokaform.mokaformserver.answer.domain.OXAnswer;
+import com.mokaform.mokaformserver.answer.dto.request.AnswerCreateRequest;
+import com.mokaform.mokaformserver.answer.repository.AnswerRepository;
+import com.mokaform.mokaformserver.answer.repository.EssayAnswerRepository;
+import com.mokaform.mokaformserver.answer.repository.MultipleChoiceAnswerRepository;
+import com.mokaform.mokaformserver.answer.repository.OXAnswerRepository;
+import com.mokaform.mokaformserver.common.exception.ApiException;
+import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
+import com.mokaform.mokaformserver.survey.domain.MultipleChoiceQuestion;
+import com.mokaform.mokaformserver.survey.domain.Question;
+import com.mokaform.mokaformserver.survey.repository.MultiChoiceQuestionRepository;
+import com.mokaform.mokaformserver.survey.repository.QuestionRepository;
+import com.mokaform.mokaformserver.user.domain.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class AnswerService {
+    private final AnswerRepository answerRepository;
+    private final EssayAnswerRepository essayAnswerRepository;
+    private final MultipleChoiceAnswerRepository multipleChoiceAnswerRepository;
+    private final OXAnswerRepository oxAnswerRepository;
+    private final QuestionRepository questionRepository;
+    private final MultiChoiceQuestionRepository multiChoiceQuestionRepository;
+
+    public AnswerService(AnswerRepository answerRepository, EssayAnswerRepository essayAnswerRepository,
+                         MultipleChoiceAnswerRepository multipleChoiceAnswerRepository,
+                         OXAnswerRepository oxAnswerRepository,
+                         QuestionRepository questionRepository,
+                         MultiChoiceQuestionRepository multiChoiceQuestionRepository) {
+        this.answerRepository = answerRepository;
+        this.essayAnswerRepository = essayAnswerRepository;
+        this.multipleChoiceAnswerRepository = multipleChoiceAnswerRepository;
+        this.oxAnswerRepository = oxAnswerRepository;
+        this.questionRepository = questionRepository;
+        this.multiChoiceQuestionRepository = multiChoiceQuestionRepository;
+    }
+
+    @Transactional
+    public void createAnswer(AnswerCreateRequest request, User user) {
+
+        request.getEssayAnswers()
+                .forEach(answer -> {
+                            Answer savedAnswer = saveAnswer(Answer.builder()
+                                    .user(user)
+                                    .question(getQuestion(answer.getQuestionId()))
+                                    .build());
+
+                            saveEssayAnswer(
+                                    EssayAnswer.builder()
+                                            .answer(savedAnswer)
+                                            .answerContent(answer.getAnswerContent())
+                                            .build());
+                        }
+
+                );
+
+        request.getMultipleChoiceAnswers()
+                .forEach(answer -> {
+                    Answer savedAnswer = saveAnswer(Answer.builder()
+                            .user(user)
+                            .question(getQuestion(answer.getQuestionId()))
+                            .build());
+
+                    MultipleChoiceQuestion multipleChoiceQuestion = getMultipleChoiceQuestion(answer.getMultiQuestionId());
+
+                    saveMultipleChoiceAnswer(
+                            MultipleChoiceAnswer.builder()
+                                    .answer(savedAnswer)
+                                    .multipleChoiceQuestion(multipleChoiceQuestion)
+                                    .build()
+                    );
+                });
+
+        request.getOxAnswers()
+                .forEach(answer -> {
+                            Answer savedAnswer = saveAnswer(Answer.builder()
+                                    .user(user)
+                                    .question(getQuestion(answer.getQuestionId()))
+                                    .build());
+
+                            saveOXAnswer(
+                                    OXAnswer.builder()
+                                            .answer(savedAnswer)
+                                            .isYes(answer.getIsYes())
+                                            .build()
+                            );
+                        }
+                );
+
+    }
+
+    private Question getQuestion(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() ->
+                        new ApiException(CommonErrorCode.INVALID_PARAMETER));
+    }
+
+    private MultipleChoiceQuestion getMultipleChoiceQuestion(Long multiQuestionId) {
+        return multiChoiceQuestionRepository.findById(multiQuestionId)
+                .orElseThrow(() ->
+                        new ApiException(CommonErrorCode.INVALID_PARAMETER));
+    }
+
+    private Answer saveAnswer(Answer answer) {
+        Answer savedAnswer = answerRepository.save(answer);
+        return savedAnswer;
+    }
+
+    private void saveEssayAnswer(EssayAnswer essayAnswer) {
+        essayAnswerRepository.save(essayAnswer);
+    }
+
+    private void saveMultipleChoiceAnswer(MultipleChoiceAnswer multipleChoiceAnswer) {
+        multipleChoiceAnswerRepository.save(multipleChoiceAnswer);
+    }
+
+    private void saveOXAnswer(OXAnswer oxAnswer) {
+        oxAnswerRepository.save(oxAnswer);
+    }
+
+}


### PR DESCRIPTION
## 설문 답변 저장 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-64

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
* answer, multiple_chocie_answer, ox_answer, essay_answer 테이블 생성 후 데이터 저장
* 로그인 미구현으로 인해 query parameter로 `userId`넣어서 요청해야 함
* url : `POST /api/v1/answer`

### 리뷰 포인트
* request 예시
<b>MOKA-56 의 user 및 survey 저장 후 해야함.</b>
<img width="978" alt="image" src="https://user-images.githubusercontent.com/63833392/195977190-cad639c1-d4a3-4d9d-a029-862919318469.png">

```
{
    "essayAnswers": [
        {
            "questionId": 1,
            "answerContent": "주관식 답변입니다."
        }
    ],
    "multipleChoiceAnswers": [
        {
            "questionId": 2,
            "multiQuestionId": 1
        },
        {
            "questionId": 3,
            "multiQuestionId": 4
        }
    ],
    "oxAnswers": [
        {
            "questionId": 4,
            "isYes": true
        }
    ]
}
```

<b>주관식, 찬부식의 경우 questionId, 객관식의 경우 questionId / multiQuestionId 를 넘기기 때문에 설문 상세 조회 페이지 API 에서 해당 값도 추가로 보내줘야 할 것 같아요 ~! </b>

