### PR TITLE
공개된 설문 목록 조회 API 구현 (MOKA-66)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/SurveyErrorCode.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/SurveyErrorCode.java
@@ -1,0 +1,34 @@
+package com.mokaform.mokaformserver.common.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public enum SurveyErrorCode implements ErrorCode {
+
+    INVALID_SORT_TYPE("S001", HttpStatus.BAD_REQUEST, "Invalid survey sort type"),
+    ;
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    SurveyErrorCode(String code, HttpStatus httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/common/response/PageResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/response/PageResponse.java
@@ -1,0 +1,37 @@
+package com.mokaform.mokaformserver.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(Include.NON_NULL)
+public class PageResponse<T> {
+
+    private final List<T> content;
+    private final int numberOfElements;
+    private final long totalElements;
+    private final int totalPages;
+    private final long offset;
+    private final int pageSize;
+    private final int pageNumber;
+    private final boolean first;
+    private final boolean last;
+
+    @Builder
+    public PageResponse(Page<T> page) {
+        this.content = page.getContent();
+        this.numberOfElements = page.getNumberOfElements();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.offset = page.getPageable().getOffset();
+        this.pageSize = page.getPageable().getPageSize();
+        this.pageNumber = page.getPageable().getPageNumber();
+        this.first = page.isFirst();
+        this.last = page.isLast();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/common/util/QuerydslCustomUtils.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/util/QuerydslCustomUtils.java
@@ -1,0 +1,42 @@
+package com.mokaform.mokaformserver.common.util;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+
+import java.util.function.Supplier;
+
+public class QuerydslCustomUtils {
+
+    public static BooleanExpression alwaysTrue() {
+        return Expressions.asBoolean(true).isTrue();
+    }
+
+    public static BooleanExpression alwaysFalse() {
+        return Expressions.asBoolean(true).isFalse();
+    }
+
+    public static BooleanBuilder nullSafeBooleanBuilder(Supplier<BooleanExpression> f) {
+        try {
+            return new BooleanBuilder(f.get());
+        } catch (IllegalArgumentException e) {
+            return new BooleanBuilder();
+        }
+    }
+
+    /**
+     * If all conditions are null,
+     * returns BooleanExpression that is always false
+     *
+     * @param conditions
+     * @return BooleanExpression
+     */
+    public static Predicate nullSafeConditions(Predicate... conditions) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        for (Predicate condition : conditions) {
+            booleanBuilder.and(condition);
+        }
+        return alwaysFalse().or(booleanBuilder);
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
@@ -3,17 +3,23 @@ package com.mokaform.mokaformserver.survey.controller;
 import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
 import com.mokaform.mokaformserver.common.response.ApiResponse;
+import com.mokaform.mokaformserver.common.response.PageResponse;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
+import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
 import com.mokaform.mokaformserver.user.domain.User;
 import com.mokaform.mokaformserver.user.repository.UserRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.Objects;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RestController
 @RequestMapping("/api/v1/survey")
@@ -59,6 +65,17 @@ public class SurveyController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("설문 상세 조회가 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse> getSurveyInfos(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable) {
+        PageResponse<SurveyInfoResponse> response = surveyService.getSurveyInfos(pageable);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("설문 다건 조회가 성공하였습니다.")
                         .data(response)
                         .build());
     }

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/mapping/SurveyInfoMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/mapping/SurveyInfoMapping.java
@@ -1,0 +1,40 @@
+package com.mokaform.mokaformserver.survey.dto.mapping;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class SurveyInfoMapping {
+
+    private Long surveyId;
+    private String title;
+    private String summary;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isAnonymous;
+    private Boolean isPublic;
+    private String sharingKey;
+
+    private Long surveyeeCount;
+
+    @Builder
+    public SurveyInfoMapping(Long surveyId, String title,
+                             String summary, LocalDate startDate,
+                             LocalDate endDate, Boolean isAnonymous,
+                             Boolean isPublic, String sharingKey,
+                             Long surveyeeCount) {
+        this.surveyId = surveyId;
+        this.title = title;
+        this.summary = summary;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isAnonymous = isAnonymous;
+        this.isPublic = isPublic;
+        this.sharingKey = sharingKey;
+        this.surveyeeCount = surveyeeCount;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SurveyInfoResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SurveyInfoResponse.java
@@ -1,0 +1,37 @@
+package com.mokaform.mokaformserver.survey.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class SurveyInfoResponse {
+
+    private final Long surveyId;
+    private final String title;
+    private final String summary;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final Boolean isAnonymous;
+    private final Boolean isPublic;
+    private final String sharingKey;
+
+    private final Long surveyeeCount;
+
+    public SurveyInfoResponse(SurveyInfoMapping surveyInfoMapping) {
+        this.surveyId = surveyInfoMapping.getSurveyId();
+        this.title = surveyInfoMapping.getTitle();
+        this.summary = surveyInfoMapping.getSummary();
+        this.startDate = surveyInfoMapping.getStartDate();
+        this.endDate = surveyInfoMapping.getEndDate();
+        this.isAnonymous = surveyInfoMapping.getIsAnonymous();
+        this.isPublic = surveyInfoMapping.getIsPublic();
+        this.sharingKey = surveyInfoMapping.getSharingKey();
+        this.surveyeeCount = surveyInfoMapping.getSurveyeeCount();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
@@ -1,0 +1,10 @@
+package com.mokaform.mokaformserver.survey.repository;
+
+import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SurveyCustomRepository {
+
+    Page<SurveyInfoMapping> findSurveyInfos(Pageable pageable);
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
@@ -1,0 +1,93 @@
+package com.mokaform.mokaformserver.survey.repository;
+
+import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
+import com.mokaform.mokaformserver.survey.repository.enums.SurveySortType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.Assert;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.mokaform.mokaformserver.answer.domain.QAnswer.answer;
+import static com.mokaform.mokaformserver.common.util.QuerydslCustomUtils.nullSafeBooleanBuilder;
+import static com.mokaform.mokaformserver.survey.domain.QQuestion.question;
+import static com.mokaform.mokaformserver.survey.domain.QSurvey.survey;
+
+@RequiredArgsConstructor
+public class SurveyCustomRepositoryImpl implements SurveyCustomRepository {
+
+    private static final String PAGEABLE_MUST_NOT_BE_NULL = "The given pageable must not be null!";
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<SurveyInfoMapping> findSurveyInfos(Pageable pageable) {
+        checkPageable(pageable);
+
+        List<SurveyInfoMapping> content = queryFactory
+                .select(
+                        Projections.fields(SurveyInfoMapping.class,
+                                survey.surveyId,
+                                survey.title,
+                                survey.summary,
+                                survey.startDate,
+                                survey.endDate,
+                                survey.isAnonymous,
+                                survey.isPublic,
+                                survey.sharingKey,
+                                answer.user.id.countDistinct().as("surveyeeCount")))
+                .from(survey)
+                .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))
+                .leftJoin(answer).on(question.questionId.eq(answer.question.questionId))
+                .where(
+                        survey.isPublic.isTrue(),
+                        survey.isDeleted.isFalse(),
+                        filterOngoingSurvey())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .groupBy(survey.surveyId)
+                .orderBy(getAllOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(survey.countDistinct())
+                .from(survey)
+                .where(survey.isPublic.isTrue(),
+                        survey.isDeleted.isFalse(),
+                        filterOngoingSurvey());
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanBuilder filterOngoingSurvey() {
+        LocalDate now = LocalDate.now();
+        return nullSafeBooleanBuilder(() ->
+                survey.startDate.loe(now).and(survey.endDate.goe(now)));
+    }
+
+    private void checkPageable(Pageable pageable) {
+        Assert.notNull(pageable, PAGEABLE_MUST_NOT_BE_NULL);
+    }
+
+    private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {
+        if (pageable.getSort().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return pageable.getSort().stream()
+                .map(order -> SurveySortType.getSortType(order.getProperty())
+                        .getOrderSpecifier(order.getDirection().isAscending() ? Order.ASC : Order.DESC))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface SurveyRepository extends JpaRepository<Survey, Long> {
+public interface SurveyRepository extends JpaRepository<Survey, Long>, SurveyCustomRepository {
 
     Optional<Survey> findBySharingKey(String sharingKey);
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/enums/SurveySortType.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/enums/SurveySortType.java
@@ -1,0 +1,38 @@
+package com.mokaform.mokaformserver.survey.repository.enums;
+
+import com.mokaform.mokaformserver.common.exception.ApiException;
+import com.mokaform.mokaformserver.common.exception.errorcode.SurveyErrorCode;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+import java.util.Arrays;
+
+import static com.mokaform.mokaformserver.answer.domain.QAnswer.answer;
+import static com.mokaform.mokaformserver.survey.domain.QSurvey.survey;
+
+public enum SurveySortType {
+
+    CREATED_AT("createdAt", survey.createdAt),
+    SURVEYEE_COUNT("surveyeeCount", answer.user.id.countDistinct());
+
+    private final String property;
+    private final Expression target;
+
+    SurveySortType(String property, Expression target) {
+        this.property = property;
+        this.target = target;
+    }
+
+    public OrderSpecifier<?> getOrderSpecifier(Order direction) {
+        return new OrderSpecifier(direction, this.target);
+    }
+
+    public static SurveySortType getSortType(String property) {
+        return Arrays.stream(SurveySortType.values())
+                .filter(sortType -> sortType.property.equals(property))
+                .findAny()
+                .orElseThrow(() ->
+                        new ApiException(SurveyErrorCode.INVALID_SORT_TYPE));
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -2,16 +2,21 @@ package com.mokaform.mokaformserver.survey.service;
 
 import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
+import com.mokaform.mokaformserver.common.response.PageResponse;
 import com.mokaform.mokaformserver.survey.domain.MultipleChoiceQuestion;
 import com.mokaform.mokaformserver.survey.domain.Question;
 import com.mokaform.mokaformserver.survey.domain.Survey;
+import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
+import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.repository.MultiChoiceQuestionRepository;
 import com.mokaform.mokaformserver.survey.repository.QuestionRepository;
 import com.mokaform.mokaformserver.survey.repository.SurveyRepository;
 import com.mokaform.mokaformserver.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,6 +92,11 @@ public class SurveyService {
         Survey survey = getSurveyBySharingKey(sharingKey);
 
         return getSurveyDetails(survey);
+    }
+
+    public PageResponse<SurveyInfoResponse> getSurveyInfos(Pageable pageable) {
+        Page<SurveyInfoMapping> surveyInfos = surveyRepository.findSurveyInfos(pageable);
+        return new PageResponse<>(surveyInfos.map(SurveyInfoResponse::new));
     }
 
     private SurveyDetailsResponse getSurveyDetails(Survey survey) {


### PR DESCRIPTION
## 공개된 설문 목록 조회 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-66

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 메인페이지에서 사용할 `공개된 설문 목록`을 조회하는 api
- `공개된 설문 목록`이란 설문 설정이 `공개`로 되어 있고 `요청 당일이 설문 시작일과 종료일 사이`인 설문을 뜻함
- QueryDSL을 사용하여 repository 구현
- PageResponse를 만들어서 사용하지 않는 `Page` 응답값은 보내지 않음
- Survey 도메인의 `SurveyErrorCode` enum 생성
- 설문 목록 조회는 `createdAt`, `surveyeeCount`를 기준으로 `asc`(오름차순), `desc`(내림차순)으로 정렬 가능

### 리뷰 포인트
<!-- 오류 있는지 함께 확인해주세요 -->
- 응답값에 빠진 데이터가 있는지 확인해주세요!
  - 설문 카테고리가 빠졌군요,,, 확인해보니 설문 생성 api에서부터 카테고리를 넣어주지 않네요! 현재 react 화면상에도 설문 옵션 모달에서 카테고리를 설정하는 부분이 없습니다ㅠㅠ 이 부분 수정해야겠네요

### 요청 예시
**request**
- url: `/api/v1/survey/list`
- query parameters
  - `page`: 페이지 번호 (0부터 시작)
  - `size`: 한 페이지에 들어갈 element 개수
  - `sort`: "`createdAt`(설문 생성 일시), `surveyeeCount`(설문 응답자 수)", "`asc`(오름차순),`desc`(내림차순)"
  - 예: `http://localhost:8080/api/v1/survey/list?page=0&size=2&sort=surveyeeCount,desc` -> 첫번째 페이지, 한 페이지에 2개 데이터, 설문 응답자 수를 기준으로 내림차순 정렬
  - default value는 `page=0, size=10, sort=createdAt,desc`-> `http://localhost:8080/api/v1/survey/list`만 보냈을 때를 의미함
<img width="1283" alt="스크린샷 2022-10-16 오전 2 56 43" src="https://user-images.githubusercontent.com/53249897/196001312-6a4158aa-8a7b-4eee-a32e-b9d7f6c02bee.png">


**response**
```json
{
    "message": "설문 다건 조회가 성공하였습니다.",
    "data": {
        "content": [
            {
                "surveyId": 10,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": true,
                "sharingKey": "dPLhkp3vim",
                "surveyeeCount": 2
            },
            {
                "surveyId": 6,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": true,
                "sharingKey": "y71WPDR93w",
                "surveyeeCount": 0
            }
        ],
        "numberOfElements": 2,
        "totalElements": 4,
        "totalPages": 2,
        "offset": 0,
        "pageSize": 2,
        "pageNumber": 0,
        "first": true,
        "last": false
    }
}
```

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 테스트 코드 작성
- [ ] validation 추가