### PR TITLE
설문 삭제 API 구현  (MOKA-57)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
@@ -6,6 +6,7 @@ import com.mokaform.mokaformserver.common.response.ApiResponse;
 import com.mokaform.mokaformserver.common.response.PageResponse;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
+import com.mokaform.mokaformserver.survey.dto.response.SurveyDeleteResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
@@ -76,6 +77,17 @@ public class SurveyController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("설문 다건 조회가 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    @DeleteMapping("/{surveyId}")
+    public ResponseEntity<ApiResponse> removeSurvey(@PathVariable(value = "surveyId") Long surveyId) {
+        SurveyDeleteResponse response = surveyService.deleteSurvey(surveyId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("설문 삭제가 성공하였습니다.")
                         .data(response)
                         .build());
     }

--- a/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/domain/Survey.java
@@ -72,4 +72,8 @@ public class Survey extends BaseEntity {
         this.sharingKey = RandomStringUtils.random(10, true, true);
         this.isDeleted = false;
     }
+
+    public void updateIsDeleted(Boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SurveyDeleteResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SurveyDeleteResponse.java
@@ -1,0 +1,17 @@
+package com.mokaform.mokaformserver.survey.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class SurveyDeleteResponse {
+
+    private final Long surveyId;
+
+    public SurveyDeleteResponse(Long surveyId) {
+        this.surveyId = surveyId;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -10,6 +10,7 @@ import com.mokaform.mokaformserver.survey.domain.SurveyCategory;
 import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
+import com.mokaform.mokaformserver.survey.dto.response.SurveyDeleteResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.repository.MultiChoiceQuestionRepository;
@@ -107,6 +108,13 @@ public class SurveyService {
         return new PageResponse<>(
                 surveyInfos.map(surveyInfo ->
                         new SurveyInfoResponse(surveyInfo, getSurveyCategories(surveyInfo.getSurveyId()))));
+    }
+
+    @Transactional
+    public SurveyDeleteResponse deleteSurvey(Long surveyId) {
+        Survey survey = getSurveyById(surveyId);
+        survey.updateIsDeleted(true);
+        return new SurveyDeleteResponse(survey.getSurveyId());
     }
 
     private SurveyDetailsResponse getSurveyDetails(Survey survey) {


### PR DESCRIPTION
## 제목설문 삭제 API 구현<!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-57

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- Survey의 isDeleted를 true로 변경하여 soft delete 구현

### 예시
**request**
- url: `http://localhost:8080/api/v1/survey/{surveyId}`
- `surveyId`: 삭제하려는 survey의 id
<img width="1283" alt="스크린샷 2022-10-16 오후 7 08 02" src="https://user-images.githubusercontent.com/53249897/196029585-7315077e-0eda-45cf-9ffe-e472169584f5.png">

**response**
```json
{
    "message": "설문 삭제가 성공하였습니다.",
    "data": {
        "surveyId": 1
    }
}
```

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] validation 추가
- [ ] 테스트 코드 작성