### PR TITLE
내가 참여한 설문 목록 조회 API 구현 (MOKA-72)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/mapping/SubmittedSurveyInfoMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/mapping/SubmittedSurveyInfoMapping.java
@@ -1,0 +1,39 @@
+package com.mokaform.mokaformserver.survey.dto.mapping;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@NoArgsConstructor
+@Getter
+public class SubmittedSurveyInfoMapping {
+
+    private Long surveyId;
+    private String title;
+    private String summary;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Boolean isAnonymous;
+    private Boolean isPublic;
+    private String sharingKey;
+    private Boolean isDeleted;
+
+    @Builder
+    public SubmittedSurveyInfoMapping(Long surveyId, String title,
+                                      String summary, LocalDate startDate,
+                                      LocalDate endDate, Boolean isAnonymous,
+                                      Boolean isPublic, String sharingKey,
+                                      Boolean isDeleted) {
+        this.surveyId = surveyId;
+        this.title = title;
+        this.summary = summary;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isAnonymous = isAnonymous;
+        this.isPublic = isPublic;
+        this.sharingKey = sharingKey;
+        this.isDeleted = isDeleted;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
@@ -1,0 +1,36 @@
+package com.mokaform.mokaformserver.survey.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class SubmittedSurveyInfoResponse {
+
+    private final Long surveyId;
+    private final String title;
+    private final String summary;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final Boolean isAnonymous;
+    private final Boolean isPublic;
+    private final String sharingKey;
+    private final Boolean isDeleted;
+
+    public SubmittedSurveyInfoResponse(SubmittedSurveyInfoMapping surveyInfoMapping) {
+        this.surveyId = surveyInfoMapping.getSurveyId();
+        this.title = surveyInfoMapping.getTitle();
+        this.summary = surveyInfoMapping.getSummary();
+        this.startDate = surveyInfoMapping.getStartDate();
+        this.endDate = surveyInfoMapping.getEndDate();
+        this.isAnonymous = surveyInfoMapping.getIsAnonymous();
+        this.isPublic = surveyInfoMapping.getIsPublic();
+        this.sharingKey = surveyInfoMapping.getSharingKey();
+        this.isDeleted = surveyInfoMapping.getIsDeleted();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
@@ -1,5 +1,6 @@
 package com.mokaform.mokaformserver.survey.repository;
 
+import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,4 +8,6 @@ import org.springframework.data.domain.Pageable;
 public interface SurveyCustomRepository {
 
     Page<SurveyInfoMapping> findSurveyInfos(Pageable pageable, Long userId);
+
+    Page<SubmittedSurveyInfoMapping> findSubmittedSurveyInfos(Pageable pageable, Long userId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -7,8 +7,10 @@ import com.mokaform.mokaformserver.survey.domain.MultipleChoiceQuestion;
 import com.mokaform.mokaformserver.survey.domain.Question;
 import com.mokaform.mokaformserver.survey.domain.Survey;
 import com.mokaform.mokaformserver.survey.domain.SurveyCategory;
+import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
+import com.mokaform.mokaformserver.survey.dto.response.SubmittedSurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
@@ -107,6 +109,12 @@ public class SurveyService {
         return new PageResponse<>(
                 surveyInfos.map(surveyInfo ->
                         new SurveyInfoResponse(surveyInfo, getSurveyCategories(surveyInfo.getSurveyId()))));
+    }
+
+    public PageResponse<SubmittedSurveyInfoResponse> getSubmittedSurveyInfos(Pageable pageable, Long userId) {
+        Page<SubmittedSurveyInfoMapping> surveyInfos = surveyRepository.findSubmittedSurveyInfos(pageable, userId);
+        return new PageResponse<>(
+                surveyInfos.map(SubmittedSurveyInfoResponse::new));
     }
 
     private SurveyDetailsResponse getSurveyDetails(Survey survey) {

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.mokaform.mokaformserver.user.controller;
 
 import com.mokaform.mokaformserver.common.response.ApiResponse;
 import com.mokaform.mokaformserver.common.response.PageResponse;
+import com.mokaform.mokaformserver.survey.dto.response.SubmittedSurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
@@ -46,6 +47,19 @@ public class UserController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("내가 작성한 설문 다건 조회가 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    // TODO: userId는 로그인 구현 후에 수정
+    @GetMapping("/my/submitted-surveys")
+    public ResponseEntity<ApiResponse> getSubmittedSurveyInfos(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
+                                                               @RequestParam Long userId) {
+        PageResponse<SubmittedSurveyInfoResponse> response = surveyService.getSubmittedSurveyInfos(pageable, userId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("내가 참여한 설문 다건 조회가 성공하였습니다.")
                         .data(response)
                         .build());
     }


### PR DESCRIPTION
## 내가 참여한 설문 목록 조회 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-72

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 로그인한 사용자가 참여한 설문 목록을 조회할 수 있음
- 삭제된 설문, 비공개된 설문도 보내주기 때문에 클라이언트에서 해당 부분에 대해서 추가 처리가 필요합니다.
  - 예를 들어 삭제된 설문을 클릭하여 설문 상세조회를 할 때 "삭제된 설문입니다"라는 페이지 표출

### 예시
**request**
- url: `http://localhost:8080/api/v1/users/my/submitted-surveys?page=0&size=8&sort=createdAt,desc&userId=1`
- 페이징 관련 파라미터: `page`, `size`, `sort`
- `userId`: user id (로그인 구현 이후 적용 예정)
<img width="1283" alt="스크린샷 2022-10-17 오후 12 22 54" src="https://user-images.githubusercontent.com/53249897/196082542-ef4881f3-b8fc-420d-bfd6-80a734a8bd06.png">

**response**
```json
{
    "message": "내가 참여한 설문 다건 조회가 성공하였습니다.",
    "data": {
        "content": [
            {
                "surveyId": 6,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": true,
                "sharingKey": "0WvD7P2oCP",
                "isDeleted": false
            },
            {
                "surveyId": 1,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": true,
                "sharingKey": "Twuu7C9pG5",
                "isDeleted": true
            }
        ],
        "numberOfElements": 2,
        "totalElements": 2,
        "totalPages": 1,
        "offset": 0,
        "pageSize": 8,
        "pageNumber": 0,
        "first": true,
        "last": true
    }
}
```

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ]  validation 추가
- [ ] 테스트 코드 추가