### PR TITLE
내가 참여한 설문 답변 상세 조회 API 구현 (MOKA-76)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/AnswerInfoMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/AnswerInfoMapping.java
@@ -1,0 +1,17 @@
+package com.mokaform.mokaformserver.answer.dto.mapping;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class AnswerInfoMapping {
+
+    private Long answerId;
+    private Long questionId;
+
+    public AnswerInfoMapping(Long answerId, Long questionId) {
+        this.answerId = answerId;
+        this.questionId = questionId;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerDetailResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerDetailResponse.java
@@ -1,0 +1,44 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.answer.domain.EssayAnswer;
+import com.mokaform.mokaformserver.answer.domain.MultipleChoiceAnswer;
+import com.mokaform.mokaformserver.answer.domain.OXAnswer;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class AnswerDetailResponse extends AnswerResponse {
+
+    private final List<EssayAnswerResponse> essayAnswers;
+
+    private final List<MultipleChoiceAnswerResponse> multipleChoiceAnswers;
+
+    private final List<OXAnswerResponse> oxAnswers;
+
+    @Builder
+    public AnswerDetailResponse(Long surveyId, Long surveyeeId,
+                                List<EssayAnswer> essayAnswers,
+                                List<MultipleChoiceAnswer> multipleChoiceAnswers,
+                                List<OXAnswer> oxAnswers) {
+        super(surveyId, surveyeeId);
+        this.essayAnswers = essayAnswers
+                .stream()
+                .map(EssayAnswerResponse::new).
+                collect(Collectors.toList());
+        this.multipleChoiceAnswers = multipleChoiceAnswers
+                .stream()
+                .map(MultipleChoiceAnswerResponse::new)
+                .collect(Collectors.toList());
+        this.oxAnswers = oxAnswers
+                .stream()
+                .map(OXAnswerResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/AnswerResponse.java
@@ -1,0 +1,20 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class AnswerResponse {
+
+    private final Long surveyId;
+
+    private final Long surveyeeId;
+
+    public AnswerResponse(Long surveyId, Long surveyeeId) {
+        this.surveyId = surveyId;
+        this.surveyeeId = surveyeeId;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/EssayAnswerResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/EssayAnswerResponse.java
@@ -1,0 +1,24 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.answer.domain.EssayAnswer;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class EssayAnswerResponse {
+
+    private Long essayAnswerId;
+
+    private Long questionId;
+
+    private String answerContent;
+
+    public EssayAnswerResponse(EssayAnswer essayAnswer) {
+        this.essayAnswerId = essayAnswer.getEssayAnswerId();
+        this.questionId = essayAnswer.getAnswer().getQuestion().getQuestionId();
+        this.answerContent = essayAnswer.getAnswerContent();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/MultipleChoiceAnswerResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/MultipleChoiceAnswerResponse.java
@@ -1,0 +1,24 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.answer.domain.MultipleChoiceAnswer;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class MultipleChoiceAnswerResponse {
+
+    private final Long multipleChoiceAnswerId;
+
+    private final Long questionId;
+
+    private final Long multiQuestionId;
+
+    public MultipleChoiceAnswerResponse(MultipleChoiceAnswer multipleChoiceAnswer) {
+        this.multipleChoiceAnswerId = multipleChoiceAnswer.getMultipleChoiceAnswerId();
+        this.questionId = multipleChoiceAnswer.getAnswer().getQuestion().getQuestionId();
+        this.multiQuestionId = multipleChoiceAnswer.getMultipleChoiceQuestion().getMultiQuestionId();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/response/OXAnswerResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/response/OXAnswerResponse.java
@@ -1,0 +1,24 @@
+package com.mokaform.mokaformserver.answer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.answer.domain.OXAnswer;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class OXAnswerResponse {
+
+    private final Long oxAnswerId;
+
+    private final Long questionId;
+
+    private final Boolean isYes;
+
+    public OXAnswerResponse(OXAnswer oxAnswer) {
+        this.oxAnswerId = oxAnswer.getOxAnswerId();
+        this.questionId = oxAnswer.getAnswer().getQuestion().getQuestionId();
+        this.isYes = oxAnswer.getIsYes();
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepository.java
@@ -1,0 +1,10 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.dto.mapping.AnswerInfoMapping;
+
+import java.util.List;
+
+public interface AnswerCustomRepository {
+
+    List<AnswerInfoMapping> findAnswerInfos(Long surveyId, Long userId);
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepositoryImpl.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.mokaform.mokaformserver.answer.repository;
+
+import com.mokaform.mokaformserver.answer.dto.mapping.AnswerInfoMapping;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+import static com.mokaform.mokaformserver.answer.domain.QAnswer.answer;
+import static com.mokaform.mokaformserver.survey.domain.QQuestion.question;
+import static com.mokaform.mokaformserver.survey.domain.QSurvey.survey;
+
+@RequiredArgsConstructor
+public class AnswerCustomRepositoryImpl implements AnswerCustomRepository {
+
+    private static final String SURVEY_ID_MUST_NOT_BE_NULL = "The given survey id must not be null!";
+    private static final String USER_ID_MUST_NOT_BE_NULL = "The given user id must not be null!";
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<AnswerInfoMapping> findAnswerInfos(Long surveyId, Long userId) {
+        checkSurveyId(surveyId);
+        checkUserId(userId);
+        
+        return queryFactory
+                .select(
+                        Projections.fields(AnswerInfoMapping.class,
+                                answer.answerId,
+                                answer.question.questionId))
+                .from(survey)
+                .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))
+                .leftJoin(answer).on(question.questionId.eq(answer.question.questionId))
+                .where(
+                        survey.surveyId.eq(surveyId),
+                        answer.user.id.eq(userId))
+                .fetch();
+    }
+
+    private void checkSurveyId(Long surveyId) {
+        Assert.notNull(surveyId, SURVEY_ID_MUST_NOT_BE_NULL);
+    }
+
+    private void checkUserId(Long userId) {
+        Assert.notNull(userId, USER_ID_MUST_NOT_BE_NULL);
+    }
+
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerRepository.java
@@ -3,5 +3,5 @@ package com.mokaform.mokaformserver.answer.repository;
 import com.mokaform.mokaformserver.answer.domain.Answer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AnswerRepository extends JpaRepository<Answer, Long> {
+public interface AnswerRepository extends JpaRepository<Answer, Long>, AnswerCustomRepository {
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/EssayAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/EssayAnswerRepository.java
@@ -2,6 +2,13 @@ package com.mokaform.mokaformserver.answer.repository;
 
 import com.mokaform.mokaformserver.answer.domain.EssayAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface EssayAnswerRepository extends JpaRepository<EssayAnswer, Long> {
+
+    @Query("SELECT ea FROM EssayAnswer ea WHERE ea.answer.answerId = :answerId")
+    Optional<EssayAnswer> findByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/MultipleChoiceAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/MultipleChoiceAnswerRepository.java
@@ -2,6 +2,13 @@ package com.mokaform.mokaformserver.answer.repository;
 
 import com.mokaform.mokaformserver.answer.domain.MultipleChoiceAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MultipleChoiceAnswerRepository extends JpaRepository<MultipleChoiceAnswer, Long> {
+
+    @Query("SELECT mca FROM MultipleChoiceAnswer mca WHERE mca.answer.answerId = :answerId")
+    Optional<MultipleChoiceAnswer> findByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/OXAnswerRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/OXAnswerRepository.java
@@ -2,6 +2,13 @@ package com.mokaform.mokaformserver.answer.repository;
 
 import com.mokaform.mokaformserver.answer.domain.OXAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface OXAnswerRepository extends JpaRepository<OXAnswer, Long> {
+
+    @Query("SELECT oxa FROM OXAnswer oxa WHERE oxa.answer.answerId = :answerId")
+    Optional<OXAnswer> findByAnswerId(@Param("answerId") Long answerId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.mokaform.mokaformserver.user.controller;
 
+import com.mokaform.mokaformserver.answer.dto.response.AnswerDetailResponse;
+import com.mokaform.mokaformserver.answer.service.AnswerService;
 import com.mokaform.mokaformserver.common.response.ApiResponse;
 import com.mokaform.mokaformserver.common.response.PageResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SubmittedSurveyInfoResponse;
@@ -24,10 +26,14 @@ public class UserController {
 
     private final UserService userService;
     private final SurveyService surveyService;
+    private final AnswerService answerService;
 
-    public UserController(UserService userService, SurveyService surveyService) {
+    public UserController(UserService userService,
+                          SurveyService surveyService,
+                          AnswerService answerService) {
         this.userService = userService;
         this.surveyService = surveyService;
+        this.answerService = answerService;
     }
 
     @PostMapping("/signup")
@@ -62,6 +68,19 @@ public class UserController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("내가 참여한 설문 다건 조회가 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    // TODO: userId는 로그인 구현 후에 수정
+    @GetMapping("/my/submitted-surveys/{surveyId}")
+    public ResponseEntity<ApiResponse> getSubmittedSurveyDetail(@PathVariable(value = "surveyId") Long surveyId,
+                                                                @RequestParam Long userId) {
+        AnswerDetailResponse response = answerService.getAnswerDetail(surveyId, userId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("내가 참여한 설문 상세 조회가 성공하였습니다.")
                         .data(response)
                         .build());
     }


### PR DESCRIPTION
## 내가 참여한 설문 답변 상세 조회 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-76

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- surveyId, userId를 통해 사용자가 답변한 내용을 조회 (userId는 로그인 구현 이후 수정할 예정)
- querydsl을 사용하여 구현

### 요청 예시
**request**
- url: GET `http://localhost:8080/api/v1/users/my/submitted-surveys/{surveyId}?userId=`
- path variable: `surveyId` - survey의 id
- query params: `userId` - user의 id
<img width="1239" alt="스크린샷 2022-10-17 오후 7 21 51" src="https://user-images.githubusercontent.com/53249897/196153744-2c53f9a8-99ab-47d7-a9f4-b9b03ac539ef.png">

**response**

```json
{
    "message": "내가 참여한 설문 상세 조회가 성공하였습니다.",
    "data": {
        "surveyId": 6,
        "surveyeeId": 1,
        "essayAnswers": [
            {
                "essayAnswerId": 1,
                "questionId": 21,
                "answerContent": "주관식 답변입니다."
            }
        ],
        "multipleChoiceAnswers": [
            {
                "multipleChoiceAnswerId": 1,
                "questionId": 22,
                "multiQuestionId": 1
            },
            {
                "multipleChoiceAnswerId": 2,
                "questionId": 23,
                "multiQuestionId": 6
            }
        ],
        "oxAnswers": [
            {
                "oxAnswerId": 1,
                "questionId": 24,
                "isYes": true
            }
        ]
    }
}
```

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] validation 추가
- [ ] 테스트 코드 추가
- [ ] EssayAnswer, MultipleChoiceAnswer, OXAnswer 엔티티를 상속 전략으로 변경할지에 대한 고민