### PR TITLE
[HOT!] 내가 작성한 설문 목록 조회 API 응답값에 설문 카테고리 추가 (MOKA-83)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
@@ -1,10 +1,14 @@
 package com.mokaform.mokaformserver.survey.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.survey.domain.SurveyCategory;
+import com.mokaform.mokaformserver.survey.domain.enums.Category;
 import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -22,7 +26,9 @@ public class SubmittedSurveyInfoResponse {
     private final String sharingKey;
     private final Boolean isDeleted;
 
-    public SubmittedSurveyInfoResponse(SubmittedSurveyInfoMapping surveyInfoMapping) {
+    private final List<Category> surveyCategories;
+
+    public SubmittedSurveyInfoResponse(SubmittedSurveyInfoMapping surveyInfoMapping, List<SurveyCategory> surveyCategory) {
         this.surveyId = surveyInfoMapping.getSurveyId();
         this.title = surveyInfoMapping.getTitle();
         this.summary = surveyInfoMapping.getSummary();
@@ -32,5 +38,9 @@ public class SubmittedSurveyInfoResponse {
         this.isPublic = surveyInfoMapping.getIsPublic();
         this.sharingKey = surveyInfoMapping.getSharingKey();
         this.isDeleted = surveyInfoMapping.getIsDeleted();
+        this.surveyCategories = surveyCategory
+                .stream()
+                .map(SurveyCategory::getCategory)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -10,11 +10,7 @@ import com.mokaform.mokaformserver.survey.domain.SurveyCategory;
 import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.request.SurveyCreateRequest;
-import com.mokaform.mokaformserver.survey.dto.response.SubmittedSurveyInfoResponse;
-import com.mokaform.mokaformserver.survey.dto.response.SurveyCreateResponse;
-import com.mokaform.mokaformserver.survey.dto.response.SurveyDeleteResponse;
-import com.mokaform.mokaformserver.survey.dto.response.SurveyDetailsResponse;
-import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
+import com.mokaform.mokaformserver.survey.dto.response.*;
 import com.mokaform.mokaformserver.survey.repository.MultiChoiceQuestionRepository;
 import com.mokaform.mokaformserver.survey.repository.QuestionRepository;
 import com.mokaform.mokaformserver.survey.repository.SurveyCategoryRepository;
@@ -115,7 +111,8 @@ public class SurveyService {
     public PageResponse<SubmittedSurveyInfoResponse> getSubmittedSurveyInfos(Pageable pageable, Long userId) {
         Page<SubmittedSurveyInfoMapping> surveyInfos = surveyRepository.findSubmittedSurveyInfos(pageable, userId);
         return new PageResponse<>(
-                surveyInfos.map(SubmittedSurveyInfoResponse::new));
+                surveyInfos.map(submittedSurveyInfo ->
+                        new SubmittedSurveyInfoResponse(submittedSurveyInfo, getSurveyCategories(submittedSurveyInfo.getSurveyId()))));
     }
 
     @Transactional


### PR DESCRIPTION
## 내가 작성한 설문 목록 조회 API 응답값에 설문 카테고리 추가 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-83

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 내가 작성한 설문 목록 조회 response DTO에 survey category 추가

### 요청 예시 ([내가 참여한 설문 목록 조회 API 구현 (MOKA-72)](https://github.com/moka-team/mokaform-server/pull/13)과 요청 동일)
**바뀐 response body**

```json
{
    "message": "내가 참여한 설문 다건 조회가 성공하였습니다.",
    "data": {
        "content": [
            {
                "surveyId": 6,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": false,
                "sharingKey": "aDF6HqO1if",
                "isDeleted": false,
                "surveyCategories": [
                    "DAILY_LIFE"
                ]
            }
        ],
        "numberOfElements": 1,
        "totalElements": 1,
        "totalPages": 1,
        "offset": 0,
        "pageSize": 8,
        "pageNumber": 0,
        "first": true,
        "last": true
    }
}
```
