### PR TITLE
내가 참여한 설문 목록 조회 API 응답값에 응답자 수 추가 (MOKA-87)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/SubmittedSurveyInfoResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.mokaform.mokaformserver.survey.domain.SurveyCategory;
 import com.mokaform.mokaformserver.survey.domain.enums.Category;
 import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -26,9 +27,14 @@ public class SubmittedSurveyInfoResponse {
     private final String sharingKey;
     private final Boolean isDeleted;
 
+    private final Long surveyeeCount;
+
     private final List<Category> surveyCategories;
 
-    public SubmittedSurveyInfoResponse(SubmittedSurveyInfoMapping surveyInfoMapping, List<SurveyCategory> surveyCategory) {
+    @Builder
+    public SubmittedSurveyInfoResponse(SubmittedSurveyInfoMapping surveyInfoMapping,
+                                       Long surveyeeCount,
+                                       List<SurveyCategory> surveyCategory) {
         this.surveyId = surveyInfoMapping.getSurveyId();
         this.title = surveyInfoMapping.getTitle();
         this.summary = surveyInfoMapping.getSummary();
@@ -38,6 +44,7 @@ public class SubmittedSurveyInfoResponse {
         this.isPublic = surveyInfoMapping.getIsPublic();
         this.sharingKey = surveyInfoMapping.getSharingKey();
         this.isDeleted = surveyInfoMapping.getIsDeleted();
+        this.surveyeeCount = surveyeeCount;
         this.surveyCategories = surveyCategory
                 .stream()
                 .map(SurveyCategory::getCategory)

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
@@ -10,4 +10,6 @@ public interface SurveyCustomRepository {
     Page<SurveyInfoMapping> findSurveyInfos(Pageable pageable, Long userId);
 
     Page<SubmittedSurveyInfoMapping> findSubmittedSurveyInfos(Pageable pageable, Long userId);
+
+    Long countSurveyee(Long surveyId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
@@ -32,6 +32,7 @@ public class SurveyCustomRepositoryImpl implements SurveyCustomRepository {
 
     private static final String PAGEABLE_MUST_NOT_BE_NULL = "The given pageable must not be null!";
     private static final String USER_ID_MUST_NOT_BE_NULL = "The given user id must not be null!";
+    private static final String SURVEY_ID_MUST_NOT_BE_NULL = "The given survey id must not be null!";
 
     private final JPAQueryFactory queryFactory;
 
@@ -110,6 +111,20 @@ public class SurveyCustomRepositoryImpl implements SurveyCustomRepository {
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
+    @Override
+    public Long countSurveyee(Long surveyId) {
+        checkSurveyId(surveyId);
+
+        return queryFactory
+                .select(answer.user.id.countDistinct())
+                .from(survey)
+                .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))
+                .leftJoin(answer).on(question.questionId.eq(answer.question.questionId))
+                .where(
+                        survey.surveyId.eq(surveyId))
+                .fetchOne();
+    }
+
     private BooleanExpression filterMySurvey(Long userId) {
         if (Objects.isNull(userId)) {
             return survey.isPublic.isTrue()
@@ -131,6 +146,10 @@ public class SurveyCustomRepositoryImpl implements SurveyCustomRepository {
 
     private void checkUserId(Long userId) {
         Assert.notNull(userId, USER_ID_MUST_NOT_BE_NULL);
+    }
+
+    private void checkSurveyId(Long surveyId) {
+        Assert.notNull(surveyId, SURVEY_ID_MUST_NOT_BE_NULL);
     }
 
     private List<OrderSpecifier> getAllOrderSpecifiers(Pageable pageable) {

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -112,7 +112,11 @@ public class SurveyService {
         Page<SubmittedSurveyInfoMapping> surveyInfos = surveyRepository.findSubmittedSurveyInfos(pageable, userId);
         return new PageResponse<>(
                 surveyInfos.map(submittedSurveyInfo ->
-                        new SubmittedSurveyInfoResponse(submittedSurveyInfo, getSurveyCategories(submittedSurveyInfo.getSurveyId()))));
+                        SubmittedSurveyInfoResponse.builder()
+                                .surveyInfoMapping(submittedSurveyInfo)
+                                .surveyeeCount(surveyRepository.countSurveyee(submittedSurveyInfo.getSurveyId()))
+                                .surveyCategory(getSurveyCategories(submittedSurveyInfo.getSurveyId()))
+                                .build()));
     }
 
     @Transactional


### PR DESCRIPTION
## 내가 참여한 설문 목록 조회 API 응답값에 응답자 수 추가  <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-87

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 설문 응답자 수 구하는 repository 구현
- 내가 참여한 설문 목록 조회 response DTO에 surveyeeCount(응답자 수) 값 추가

### 요청 예시 ([내가 참여한 설문 목록 조회 API 구현 (MOKA-72)](https://github.com/moka-team/mokaform-server/pull/13)과 요청은 동일)
**request**
- 정렬 기준: `createdAt`(생성일시), `surveyeeCount`(응답자 수)
<img width="1283" alt="스크린샷 2022-10-18 오전 12 31 35" src="https://user-images.githubusercontent.com/53249897/196219708-23fbabc4-e3b1-4306-97b9-d5a166462d33.png">

**response**

```json
{
    "message": "내가 참여한 설문 다건 조회가 성공하였습니다.",
    "data": {
        "content": [
            {
                "surveyId": 6,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": false,
                "sharingKey": "aDF6HqO1if",
                "isDeleted": false,
                "surveyeeCount": 3,
                "surveyCategories": [
                    "DAILY_LIFE"
                ]
            },
            {
                "surveyId": 1,
                "title": "이것은 설문 제목입니다.",
                "summary": "이것은 설문에 대한 간단한 설명입니다.",
                "startDate": "2022-03-22",
                "endDate": "2022-11-15",
                "isAnonymous": false,
                "isPublic": false,
                "sharingKey": "dz1zg7FOPN",
                "isDeleted": false,
                "surveyeeCount": 2,
                "surveyCategories": [
                    "DAILY_LIFE"
                ]
            }
        ],
        "numberOfElements": 2,
        "totalElements": 2,
        "totalPages": 1,
        "offset": 0,
        "pageSize": 8,
        "pageNumber": 0,
        "first": true,
        "last": true
    }
}
```
