### PR TITLE
내가 참여한 설문 답변 상세 조회 url 수정 (MOKA-88)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
@@ -15,8 +15,10 @@ import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
 import com.mokaform.mokaformserver.survey.domain.MultipleChoiceQuestion;
 import com.mokaform.mokaformserver.survey.domain.Question;
+import com.mokaform.mokaformserver.survey.domain.Survey;
 import com.mokaform.mokaformserver.survey.repository.MultiChoiceQuestionRepository;
 import com.mokaform.mokaformserver.survey.repository.QuestionRepository;
+import com.mokaform.mokaformserver.survey.repository.SurveyRepository;
 import com.mokaform.mokaformserver.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,18 +35,22 @@ public class AnswerService {
     private final OXAnswerRepository oxAnswerRepository;
     private final QuestionRepository questionRepository;
     private final MultiChoiceQuestionRepository multiChoiceQuestionRepository;
+    private final SurveyRepository surveyRepository;
 
-    public AnswerService(AnswerRepository answerRepository, EssayAnswerRepository essayAnswerRepository,
+    public AnswerService(AnswerRepository answerRepository,
+                         EssayAnswerRepository essayAnswerRepository,
                          MultipleChoiceAnswerRepository multipleChoiceAnswerRepository,
                          OXAnswerRepository oxAnswerRepository,
                          QuestionRepository questionRepository,
-                         MultiChoiceQuestionRepository multiChoiceQuestionRepository) {
+                         MultiChoiceQuestionRepository multiChoiceQuestionRepository,
+                         SurveyRepository surveyRepository) {
         this.answerRepository = answerRepository;
         this.essayAnswerRepository = essayAnswerRepository;
         this.multipleChoiceAnswerRepository = multipleChoiceAnswerRepository;
         this.oxAnswerRepository = oxAnswerRepository;
         this.questionRepository = questionRepository;
         this.multiChoiceQuestionRepository = multiChoiceQuestionRepository;
+        this.surveyRepository = surveyRepository;
     }
 
     @Transactional
@@ -102,8 +108,10 @@ public class AnswerService {
     }
 
     @Transactional(readOnly = true)
-    public AnswerDetailResponse getAnswerDetail(Long surveyId, Long userId) {
-        List<AnswerInfoMapping> answerInfos = answerRepository.findAnswerInfos(surveyId, userId);
+    public AnswerDetailResponse getAnswerDetail(String sharingKey, Long userId) {
+        Survey survey = getSurveyBySharingKey(sharingKey);
+
+        List<AnswerInfoMapping> answerInfos = answerRepository.findAnswerInfos(survey.getSurveyId(), userId);
 
         List<EssayAnswer> essayAnswers = new ArrayList<>();
         List<MultipleChoiceAnswer> multipleChoiceAnswers = new ArrayList<>();
@@ -118,7 +126,7 @@ public class AnswerService {
         });
 
         return AnswerDetailResponse.builder()
-                .surveyId(surveyId)
+                .surveyId(survey.getSurveyId())
                 .surveyeeId(userId)
                 .essayAnswers(essayAnswers)
                 .multipleChoiceAnswers(multipleChoiceAnswers)
@@ -165,6 +173,11 @@ public class AnswerService {
 
     private Optional<OXAnswer> getOxAnswer(Long answerId) {
         return oxAnswerRepository.findByAnswerId(answerId);
+    }
+
+    private Survey getSurveyBySharingKey(String sharingKey) {
+        return surveyRepository.findBySharingKey(sharingKey)
+                .orElseThrow(() -> new ApiException(CommonErrorCode.INVALID_PARAMETER));
     }
 
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -73,10 +73,10 @@ public class UserController {
     }
 
     // TODO: userId는 로그인 구현 후에 수정
-    @GetMapping("/my/submitted-surveys/{surveyId}")
-    public ResponseEntity<ApiResponse> getSubmittedSurveyDetail(@PathVariable(value = "surveyId") Long surveyId,
+    @GetMapping("/my/submitted-surveys/{sharingKey}")
+    public ResponseEntity<ApiResponse> getSubmittedSurveyDetail(@PathVariable(value = "sharingKey") String sharingKey,
                                                                 @RequestParam Long userId) {
-        AnswerDetailResponse response = answerService.getAnswerDetail(surveyId, userId);
+        AnswerDetailResponse response = answerService.getAnswerDetail(sharingKey, userId);
 
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()


### PR DESCRIPTION
## 내가 참여한 설문 답변 상세 조회 url 수정 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-88

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 내가 참여한 설문 답변 상세 조회 controller URL 수정
  - 기존: path param `surveyId`
  - 수정: path param `sharingKey`

### 요청 예시
**request**
- url: GET `http://localhost:8080/api/v1/users/my/submitted-surveys/{sharingKey}?userId=`
- path param: `sharingKey` survey의 sharingKey
- query param: `userId` user의 id
<img width="1283" alt="스크린샷 2022-10-18 오전 1 00 31" src="https://user-images.githubusercontent.com/53249897/196226300-00268ee9-0946-4435-97fb-6059d8741e32.png">

**response**

```json
{
    "message": "내가 참여한 설문 상세 조회가 성공하였습니다.",
    "data": {
        "surveyId": 6,
        "surveyeeId": 1,
        "essayAnswers": [
            {
                "essayAnswerId": 1,
                "questionId": 21,
                "answerContent": "주관식 답변입니다."
            }
        ],
        "multipleChoiceAnswers": [
            {
                "multipleChoiceAnswerId": 1,
                "questionId": 22,
                "multiQuestionId": 1
            },
            {
                "multipleChoiceAnswerId": 2,
                "questionId": 23,
                "multiQuestionId": 6
            }
        ],
        "oxAnswers": [
            {
                "oxAnswerId": 1,
                "questionId": 24,
                "isYes": true
            }
        ]
    }
}
```

### 관련 PR
[내가 참여한 설문 답변 상세 조회 API 구현 (MOKA-76)](https://github.com/moka-team/mokaform-server/pull/17)