### PR TITLE
설문 통계 결과 조회 API 구현 (MOKA-84)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/EssayAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/EssayAnswerStatsMapping.java
@@ -1,0 +1,18 @@
+package com.mokaform.mokaformserver.answer.dto.mapping;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class EssayAnswerStatsMapping {
+
+    private Long questionId;
+
+    private String answerContent;
+
+    public EssayAnswerStatsMapping(Long questionId, String answerContent) {
+        this.questionId = questionId;
+        this.answerContent = answerContent;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/MultipleChoiceAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/MultipleChoiceAnswerStatsMapping.java
@@ -1,0 +1,18 @@
+package com.mokaform.mokaformserver.answer.dto.mapping;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MultipleChoiceAnswerStatsMapping {
+
+    private Long questionId;
+
+    private Long multiQuestionId;
+
+    public MultipleChoiceAnswerStatsMapping(Long questionId, Long multiQuestionId) {
+        this.questionId = questionId;
+        this.multiQuestionId = multiQuestionId;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/OXAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/OXAnswerStatsMapping.java
@@ -1,0 +1,18 @@
+package com.mokaform.mokaformserver.answer.dto.mapping;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class OXAnswerStatsMapping {
+
+    private Long questionId;
+
+    private Boolean isYes;
+
+    public OXAnswerStatsMapping(Long questionId, Boolean isYes) {
+        this.questionId = questionId;
+        this.isYes = isYes;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepository.java
@@ -1,10 +1,19 @@
 package com.mokaform.mokaformserver.answer.repository;
 
 import com.mokaform.mokaformserver.answer.dto.mapping.AnswerInfoMapping;
+import com.mokaform.mokaformserver.answer.dto.mapping.EssayAnswerStatsMapping;
+import com.mokaform.mokaformserver.answer.dto.mapping.MultipleChoiceAnswerStatsMapping;
+import com.mokaform.mokaformserver.answer.dto.mapping.OXAnswerStatsMapping;
 
 import java.util.List;
 
 public interface AnswerCustomRepository {
 
     List<AnswerInfoMapping> findAnswerInfos(Long surveyId, Long userId);
+
+    List<EssayAnswerStatsMapping> findEssayAnswers(Long surveyId);
+
+    List<MultipleChoiceAnswerStatsMapping> findMultipleChoiceAnswers(Long surveyId);
+
+    List<OXAnswerStatsMapping> findOxAnswers(Long surveyId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/AnswerStatsResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/AnswerStatsResponse.java
@@ -1,0 +1,28 @@
+package com.mokaform.mokaformserver.survey.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class AnswerStatsResponse {
+
+    private final Map<Long, List<String>> essayStats;
+    private final Map<Long, Map<Long, Long>> multipleChoiceStats;
+    private final Map<Long, Map<String, Long>> oxStats;
+
+    @Builder
+    public AnswerStatsResponse(Map<Long, List<String>> essayStats,
+                               Map<Long, Map<Long, Long>> multipleChoiceStats,
+                               Map<Long, Map<String, Long>> oxStats) {
+        this.essayStats = essayStats;
+        this.multipleChoiceStats = multipleChoiceStats;
+        this.oxStats = oxStats;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.mokaform.mokaformserver.answer.dto.response.AnswerDetailResponse;
 import com.mokaform.mokaformserver.answer.service.AnswerService;
 import com.mokaform.mokaformserver.common.response.ApiResponse;
 import com.mokaform.mokaformserver.common.response.PageResponse;
+import com.mokaform.mokaformserver.survey.dto.response.AnswerStatsResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SubmittedSurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
@@ -93,6 +94,17 @@ public class UserController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("로그읜 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    @GetMapping("/my/surveys/{surveyId}/stats")
+    public ResponseEntity<ApiResponse> getAnswerStats(@PathVariable(value = "surveyId") Long surveyId) {
+        AnswerStatsResponse response = answerService.getAnswerStats(surveyId);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("설문 통계 결과 조회 성공하였습니다.")
                         .data(response)
                         .build());
     }


### PR DESCRIPTION
## 설문 통계 결과 조회 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-84

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- querydsl를 사용하여 답변 조회 repository 구현
- 설문 통계 결과 service, controller 구현

### 요청 예시
**request**
- url: GET `http://localhost:8080/api/v1/users/my/surveys/{surveyId}/stats`
- path param: `surveyId` survey의 id
<img width="1283" alt="스크린샷 2022-10-18 오전 2 15 56" src="https://user-images.githubusercontent.com/53249897/196241410-3b111239-d6c3-4aed-873d-59cd6b0519c5.png">


**response**

```json
{
    "message": "설문 통계 결과 조회 성공하였습니다.",
    "data": {
        "essayStats": {
            "21": [
                "주관식 답변입니다.",
                "주관식 답변입니다.",
                "주관식 답변입니다.",
                "222주관식 답변입니다."
            ]
        },
        "multipleChoiceStats": {
            "22": {
                "1": 3,
                "2": 1
            },
            "23": {
                "5": 1,
                "6": 3
            }
        },
        "oxStats": {
            "24": {
                "no": 1,
                "yes": 3
            }
        }
    }
}
```


### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] validation 추가
- [ ] 테스트 코드 추가