### PR TITLE
설문 통계 결과 조회 API 응답값 수정 (MOKA-92)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/EssayAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/EssayAnswerStatsMapping.java
@@ -7,12 +7,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class EssayAnswerStatsMapping {
 
-    private Long questionId;
+    private String title;
 
     private String answerContent;
 
-    public EssayAnswerStatsMapping(Long questionId, String answerContent) {
-        this.questionId = questionId;
+    public EssayAnswerStatsMapping(String title, String answerContent) {
+        this.title = title;
         this.answerContent = answerContent;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/MultipleChoiceAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/MultipleChoiceAnswerStatsMapping.java
@@ -7,12 +7,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MultipleChoiceAnswerStatsMapping {
 
-    private Long questionId;
+    private String title;
 
-    private Long multiQuestionId;
+    private String multiQuestionContent;
 
-    public MultipleChoiceAnswerStatsMapping(Long questionId, Long multiQuestionId) {
-        this.questionId = questionId;
-        this.multiQuestionId = multiQuestionId;
+    public MultipleChoiceAnswerStatsMapping(String title, String multiQuestionContent) {
+        this.title = title;
+        this.multiQuestionContent = multiQuestionContent;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/OXAnswerStatsMapping.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/dto/mapping/OXAnswerStatsMapping.java
@@ -7,12 +7,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class OXAnswerStatsMapping {
 
-    private Long questionId;
+    private String title;
 
     private Boolean isYes;
 
-    public OXAnswerStatsMapping(Long questionId, Boolean isYes) {
-        this.questionId = questionId;
+    public OXAnswerStatsMapping(String title, Boolean isYes) {
+        this.title = title;
         this.isYes = isYes;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepositoryImpl.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/repository/AnswerCustomRepositoryImpl.java
@@ -52,7 +52,7 @@ public class AnswerCustomRepositoryImpl implements AnswerCustomRepository {
         return queryFactory
                 .select(
                         Projections.fields(EssayAnswerStatsMapping.class,
-                                answer.question.questionId,
+                                question.title,
                                 essayAnswer.answerContent))
                 .from(survey)
                 .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))
@@ -71,8 +71,8 @@ public class AnswerCustomRepositoryImpl implements AnswerCustomRepository {
         return queryFactory
                 .select(
                         Projections.fields(MultipleChoiceAnswerStatsMapping.class,
-                                answer.question.questionId,
-                                multipleChoiceAnswer.multipleChoiceQuestion.multiQuestionId))
+                                question.title,
+                                multipleChoiceAnswer.multipleChoiceQuestion.multiQuestionContent))
                 .from(survey)
                 .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))
                 .leftJoin(answer).on(question.questionId.eq(answer.question.questionId))
@@ -90,7 +90,7 @@ public class AnswerCustomRepositoryImpl implements AnswerCustomRepository {
         return queryFactory
                 .select(
                         Projections.fields(OXAnswerStatsMapping.class,
-                                answer.question.questionId,
+                                question.title,
                                 oXAnswer.isYes))
                 .from(survey)
                 .leftJoin(question).on(survey.surveyId.eq(question.survey.surveyId))

--- a/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
+++ b/src/main/java/com/mokaform/mokaformserver/answer/service/AnswerService.java
@@ -141,38 +141,38 @@ public class AnswerService {
         List<MultipleChoiceAnswerStatsMapping> multipleChoiceAnswers = answerRepository.findMultipleChoiceAnswers(surveyId);
         List<OXAnswerStatsMapping> oxAnswers = answerRepository.findOxAnswers(surveyId);
 
-        Map<Long, List<String>> essayStats = new HashMap<>();
-        Map<Long, Map<Long, Long>> multipleChoiceStats = new HashMap<>();
-        Map<Long, Map<String, Long>> oxStats = new HashMap<>();
+        Map<String, List<String>> essayStats = new HashMap<>();
+        Map<String, Map<String, Long>> multipleChoiceStats = new HashMap<>();
+        Map<String, Map<String, Long>> oxStats = new HashMap<>();
         essayAnswers.forEach(essayAnswer -> {
-            if (essayStats.containsKey(essayAnswer.getQuestionId())) {
-                List<String> value = essayStats.get(essayAnswer.getQuestionId());
+            if (essayStats.containsKey(essayAnswer.getTitle())) {
+                List<String> value = essayStats.get(essayAnswer.getTitle());
                 value.add(essayAnswer.getAnswerContent());
-                essayStats.replace(essayAnswer.getQuestionId(), value);
+                essayStats.replace(essayAnswer.getTitle(), value);
             } else {
                 ArrayList<String> list = new ArrayList<>();
                 list.add(essayAnswer.getAnswerContent());
-                essayStats.put(essayAnswer.getQuestionId(), list);
+                essayStats.put(essayAnswer.getTitle(), list);
             }
         });
         multipleChoiceAnswers.forEach(multipleChoiceAnswer -> {
-            if (multipleChoiceStats.containsKey(multipleChoiceAnswer.getQuestionId())) {
-                Map<Long, Long> value = multipleChoiceStats.get(multipleChoiceAnswer.getQuestionId());
-                if (value.containsKey(multipleChoiceAnswer.getMultiQuestionId())) {
-                    value.replace(multipleChoiceAnswer.getMultiQuestionId(), value.get(multipleChoiceAnswer.getMultiQuestionId()) + 1L);
+            if (multipleChoiceStats.containsKey(multipleChoiceAnswer.getTitle())) {
+                Map<String, Long> value = multipleChoiceStats.get(multipleChoiceAnswer.getTitle());
+                if (value.containsKey(multipleChoiceAnswer.getMultiQuestionContent())) {
+                    value.replace(multipleChoiceAnswer.getMultiQuestionContent(), value.get(multipleChoiceAnswer.getMultiQuestionContent()) + 1L);
                 } else {
-                    value.put(multipleChoiceAnswer.getMultiQuestionId(), 1L);
+                    value.put(multipleChoiceAnswer.getMultiQuestionContent(), 1L);
                 }
-                multipleChoiceStats.replace(multipleChoiceAnswer.getQuestionId(), value);
+                multipleChoiceStats.replace(multipleChoiceAnswer.getTitle(), value);
             } else {
-                Map<Long, Long> value = new HashMap<>();
-                value.put(multipleChoiceAnswer.getMultiQuestionId(), 1L);
-                multipleChoiceStats.put(multipleChoiceAnswer.getQuestionId(), value);
+                Map<String, Long> value = new HashMap<>();
+                value.put(multipleChoiceAnswer.getMultiQuestionContent(), 1L);
+                multipleChoiceStats.put(multipleChoiceAnswer.getTitle(), value);
             }
         });
         oxAnswers.forEach(oxAnswer -> {
-            if (oxStats.containsKey(oxAnswer.getQuestionId())) {
-                Map<String, Long> value = oxStats.get(oxAnswer.getQuestionId());
+            if (oxStats.containsKey(oxAnswer.getTitle())) {
+                Map<String, Long> value = oxStats.get(oxAnswer.getTitle());
                 if (oxAnswer.getIsYes() == true) {
                     if (value.containsKey("yes")) {
                         value.replace("yes", value.get("yes") + 1L);
@@ -193,7 +193,7 @@ public class AnswerService {
                 } else {
                     value.put("no", 1L);
                 }
-                oxStats.put(oxAnswer.getQuestionId(), value);
+                oxStats.put(oxAnswer.getTitle(), value);
             }
         });
 

--- a/src/main/java/com/mokaform/mokaformserver/survey/dto/response/AnswerStatsResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/dto/response/AnswerStatsResponse.java
@@ -13,14 +13,14 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 @Getter
 public class AnswerStatsResponse {
 
-    private final Map<Long, List<String>> essayStats;
-    private final Map<Long, Map<Long, Long>> multipleChoiceStats;
-    private final Map<Long, Map<String, Long>> oxStats;
+    private final Map<String, List<String>> essayStats;
+    private final Map<String, Map<String, Long>> multipleChoiceStats;
+    private final Map<String, Map<String, Long>> oxStats;
 
     @Builder
-    public AnswerStatsResponse(Map<Long, List<String>> essayStats,
-                               Map<Long, Map<Long, Long>> multipleChoiceStats,
-                               Map<Long, Map<String, Long>> oxStats) {
+    public AnswerStatsResponse(Map<String, List<String>> essayStats,
+                               Map<String, Map<String, Long>> multipleChoiceStats,
+                               Map<String, Map<String, Long>> oxStats) {
         this.essayStats = essayStats;
         this.multipleChoiceStats = multipleChoiceStats;
         this.oxStats = oxStats;


### PR DESCRIPTION
## 설문 통계 결과 조회 API 응답값 수정  <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-92

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 설문 통계 결과 조회 응답값에서 questionId, multipleChoiceQuestionId가 들어있던 부분을 질문 title, content로 변경

### 요청 예시
**request**
- 기존과 동일
- url: `http://localhost:8080/api/v1/users/my/surveys/{surveyId}/stats`
<img width="1283" alt="스크린샷 2022-10-18 오전 4 31 44" src="https://user-images.githubusercontent.com/53249897/196266075-be717add-987e-4e3f-9b40-0268f1b8bf05.png">

**response**

```json
{
    "message": "설문 통계 결과 조회 성공하였습니다.",
    "data": {
        "essayStats": {
            "1번째 질문입니다.": [
                "1번 주관식 답변입니다.",
                "1번 주관식 답변입니다.",
                "1번 주관식 답변입니다.333"
            ]
        },
        "multipleChoiceStats": {
            "3번째 질문입니다.": {
                "3번째 질문의 2번 선지입니다.": 2,
                "3번째 질문의 3번 선지입니다.": 1
            },
            "2번째 질문입니다.": {
                "2번째 질문의 2번 선지입니다.": 2,
                "2번째 질문의 3번 선지입니다.": 1
            }
        },
        "oxStats": {
            "4번째 질문입니다.": {
                "no": 1,
                "yes": 2
            }
        }
    }
}
```
