### PR TITLE
이메일 중복 확인 API 구현 (MOKA-93)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -10,6 +10,7 @@ import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
 import com.mokaform.mokaformserver.user.dto.request.LoginRequest;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
+import com.mokaform.mokaformserver.user.dto.response.DuplicateValidationResponse;
 import com.mokaform.mokaformserver.user.dto.response.LoginResponse;
 import com.mokaform.mokaformserver.user.service.UserService;
 import org.springframework.data.domain.Pageable;
@@ -105,6 +106,17 @@ public class UserController {
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("설문 통계 결과 조회 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
+    @GetMapping("/check-email-duplication")
+    public ResponseEntity<ApiResponse> checkEmailDuplication(@RequestParam(value = "email") String email) {
+        DuplicateValidationResponse response = userService.checkEmailDuplication(email);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("이메일 중복 확인 성공하였습니다.")
                         .data(response)
                         .build());
     }

--- a/src/main/java/com/mokaform/mokaformserver/user/dto/response/DuplicateValidationResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/dto/response/DuplicateValidationResponse.java
@@ -1,0 +1,17 @@
+package com.mokaform.mokaformserver.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class DuplicateValidationResponse {
+
+    private final Boolean isDuplicated;
+
+    public DuplicateValidationResponse(Boolean isDuplicated) {
+        this.isDuplicated = isDuplicated;
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndPassword(String email, String password);
+
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.mokaform.mokaformserver.user.domain.enums.Gender;
 import com.mokaform.mokaformserver.user.domain.enums.Job;
 import com.mokaform.mokaformserver.user.dto.request.LoginRequest;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
+import com.mokaform.mokaformserver.user.dto.response.DuplicateValidationResponse;
 import com.mokaform.mokaformserver.user.dto.response.LoginResponse;
 import com.mokaform.mokaformserver.user.repository.PreferenceCategoryRepository;
 import com.mokaform.mokaformserver.user.repository.UserRepository;
@@ -54,6 +55,12 @@ public class UserService {
                 .orElseThrow(() ->
                         new ApiException(UserErrorCode.USER_NOT_FOUND));
         return new LoginResponse(user);
+    }
+
+    @Transactional(readOnly = true)
+    public DuplicateValidationResponse checkEmailDuplication(String email) {
+        Boolean isDuplicated = userRepository.existsByEmail(email);
+        return new DuplicateValidationResponse(isDuplicated);
     }
 
     private void createPreferenceCategory(User user, String categoryValue) {


### PR DESCRIPTION
## 이메일 중복 확인 API 구현

### 지라 티켓 번호
MOKA-93

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 이메일 중복 확인 controller 구현
- 이메일 중복 확인 service 구현
- 이메일 중복 확인 repository 구현

### 요청 예시
**request**
- url: GET `http://localhost:8080/api/v1/users/check-email-duplication?email=`
- query param: `email` 중복확인하고 싶은 이메일 주소

<img width="1283" alt="스크린샷 2022-10-26 오후 12 06 02" src="https://user-images.githubusercontent.com/53249897/197925060-2d27c2ad-bd9d-4a8c-8120-74d16458edb6.png">

**response**
```json
{
    "message": "이메일 중복 확인 성공하였습니다.",
    "data": {
        "isDuplicated": true
    }
}
```
### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- 테스트 코드 작성 예정