### PR TITLE
닉네임 중복 확인 API 구현 (MOKA-94)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -121,4 +121,15 @@ public class UserController {
                         .build());
     }
 
+    @GetMapping("/check-nickname-duplication")
+    public ResponseEntity<ApiResponse> checkNicknameDuplication(@RequestParam(value = "nickname") String nickname) {
+        DuplicateValidationResponse response = userService.checkNicknameDuplication(nickname);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("닉네임 중복 확인 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
+
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndPassword(String email, String password);
 
     Boolean existsByEmail(String email);
+
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
@@ -63,6 +63,12 @@ public class UserService {
         return new DuplicateValidationResponse(isDuplicated);
     }
 
+    @Transactional(readOnly = true)
+    public DuplicateValidationResponse checkNicknameDuplication(String nickname) {
+        Boolean isDuplicated = userRepository.existsByNickname(nickname);
+        return new DuplicateValidationResponse(isDuplicated);
+    }
+
     private void createPreferenceCategory(User user, String categoryValue) {
         PreferenceCategory preferenceCategory = new PreferenceCategory(user, Category.valueOf(categoryValue));
         preferenceCategoryRepository.save(preferenceCategory);


### PR DESCRIPTION
## 닉네임 중복 확인 API 구현

### 지라 티켓 번호
MOKA-94

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 닉네임 중복 확인 controller 구현
- 닉네임 중복 확인 service 구현
- 닉네임 중복 확인 repository 구현

### 요청 예시
**request**
- url: GET `http://localhost:8080/api/v1/users/check-nickname-duplication?nickname=`
- query param: `nickname` 중복확인하고 싶은 닉네임

<img width="1283" alt="스크린샷 2022-10-26 오후 12 27 08" src="https://user-images.githubusercontent.com/53249897/197927547-6ea73199-1527-49b9-b805-20355984a5ae.png">


**response**
```json
{
    "message": "닉네임 중복 확인 성공하였습니다.",
    "data": {
        "isDuplicated": true
    }
}
```
### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- 테스트 코드 작성 예정