### PR TITLE
나의 정보 조회 API 구현 (MOKA-109)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -14,6 +14,7 @@ import com.mokaform.mokaformserver.user.dto.request.LocalLoginRequest;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
 import com.mokaform.mokaformserver.user.dto.response.DuplicateValidationResponse;
 import com.mokaform.mokaformserver.user.dto.response.LocalLoginResponse;
+import com.mokaform.mokaformserver.user.dto.response.UserGetResponse;
 import com.mokaform.mokaformserver.user.service.UserService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -145,4 +146,14 @@ public class UserController {
                         .build());
     }
 
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse> getUser(@AuthenticationPrincipal JwtAuthentication authentication) {
+        UserGetResponse response = userService.getUserInfo(authentication.email);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("나의 정보 조회가 성공하였습니다.")
+                        .data(response)
+                        .build());
+    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -131,12 +131,18 @@ public class UserController {
      * 사용자 로그인
      */
     @PostMapping(path = "/login")
-    public LocalLoginResponse login(@RequestBody @Valid LocalLoginRequest request) {
+    public ResponseEntity<ApiResponse> login(@RequestBody @Valid LocalLoginRequest request) {
         JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getEmail(), request.getPassword());
         Authentication resultToken = authenticationManager.authenticate(authToken);
         JwtAuthentication authentication = (JwtAuthentication) resultToken.getPrincipal();
         String refreshToken = (String) resultToken.getDetails();
-        return new LocalLoginResponse(authentication.accessToken, refreshToken, authentication.email);
+        LocalLoginResponse response = new LocalLoginResponse(authentication.accessToken, refreshToken, authentication.email);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("로그인 성공하였습니다.")
+                        .data(response)
+                        .build());
     }
 
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/dto/response/UserGetResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/dto/response/UserGetResponse.java
@@ -1,0 +1,46 @@
+package com.mokaform.mokaformserver.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mokaform.mokaformserver.survey.domain.enums.Category;
+import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
+import com.mokaform.mokaformserver.user.domain.User;
+import com.mokaform.mokaformserver.user.domain.enums.AgeGroup;
+import com.mokaform.mokaformserver.user.domain.enums.Gender;
+import com.mokaform.mokaformserver.user.domain.enums.Job;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+@JsonInclude(NON_NULL)
+@Getter
+public class UserGetResponse {
+
+    private final String email;
+
+    private final String nickname;
+
+    private final AgeGroup ageGroup;
+
+    private final Gender gender;
+
+    private final Job job;
+
+    private final String profileImage;
+
+    private final List<Category> categories;
+
+    public UserGetResponse(User user, List<PreferenceCategory> categories) {
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.ageGroup = user.getAgeGroup();
+        this.gender = user.getGender();
+        this.job = user.getJob();
+        this.profileImage = user.getProfileImage();
+        this.categories = categories.stream()
+                .map(PreferenceCategory::getCategory)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/PreferenceCategoryRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/PreferenceCategoryRepository.java
@@ -3,5 +3,9 @@ package com.mokaform.mokaformserver.user.repository;
 import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PreferenceCategoryRepository extends JpaRepository<PreferenceCategory, Long> {
+
+    List<PreferenceCategory> findByUserId(Long userId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.mokaform.mokaformserver.user.service;
 
 import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
+import com.mokaform.mokaformserver.common.exception.errorcode.UserErrorCode;
 import com.mokaform.mokaformserver.survey.domain.enums.Category;
 import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
 import com.mokaform.mokaformserver.user.domain.Role;
@@ -12,6 +13,7 @@ import com.mokaform.mokaformserver.user.domain.enums.Job;
 import com.mokaform.mokaformserver.user.domain.enums.RoleName;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
 import com.mokaform.mokaformserver.user.dto.response.DuplicateValidationResponse;
+import com.mokaform.mokaformserver.user.dto.response.UserGetResponse;
 import com.mokaform.mokaformserver.user.repository.PreferenceCategoryRepository;
 import com.mokaform.mokaformserver.user.repository.RoleRepository;
 import com.mokaform.mokaformserver.user.repository.UserRepository;
@@ -87,6 +89,15 @@ public class UserService {
                 .orElseThrow(() -> new UsernameNotFoundException("Could not found user for " + principal));
         user.checkPassword(passwordEncoder, credentials);
         return user;
+    }
+
+    @Transactional(readOnly = true)
+    public UserGetResponse getUserInfo(String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
+        List<PreferenceCategory> preferenceCategories = preferenceCategoryRepository.findByUserId(user.getId());
+
+        return new UserGetResponse(user, preferenceCategories);
     }
 
 }


### PR DESCRIPTION
## 나의 정보 조회 API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-109

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 로그인한 유저가 나의 정보를 조회할 수 있는 API 구현

### 요청 예시
**request**
- url: `http://localhost:8080/api/v1/users/my`
- 사용자 인가를 위해 헤더에 accessToken 포함해야 함
<img width="1359" alt="스크린샷 2022-10-28 오후 1 48 03" src="https://user-images.githubusercontent.com/53249897/198504854-00183aaf-3af1-4b85-afdb-464853dee2a3.png">

**response**

```json
{
    "message": "나의 정보 조회가 성공하였습니다.",
    "data": {
        "email": "a5@naver.com",
        "nickname": "a5",
        "ageGroup": "TWENTIES",
        "gender": "MALE",
        "job": "OFFICE_WORKERS",
        "categories": [
            "HOBBY",
            "SOCIAL_POLITICS",
            "LEARNING"
        ]
    }
}
````

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 테스트 코드 작성