### PR TITLE
내가 참여한 설문 목록 조회 API 에러 수정 (MOKA-116)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepositoryImpl.java
@@ -104,7 +104,9 @@ public class SurveyCustomRepositoryImpl implements SurveyCustomRepository {
 
         JPAQuery<Long> countQuery = queryFactory
                 .select(survey.surveyId.countDistinct())
-                .from(survey)
+                .from(answer)
+                .leftJoin(question).on(answer.question.questionId.eq(question.questionId))
+                .leftJoin(survey).on(question.survey.surveyId.eq(survey.surveyId))
                 .where(
                         answer.user.id.eq(userId));
 


### PR DESCRIPTION
## 내가 참여한 설문 목록 조회 API 에러 수정 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-116

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 내가 참여한 설문 목록 조회 count query 수정

### 리뷰 포인트
- 내부 쿼리 문제로 요청 방법은 이전과 동일합니다.