### PR TITLE
유저 정보 조회 API response에 userId 추가

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/dto/response/UserGetResponse.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/dto/response/UserGetResponse.java
@@ -18,6 +18,8 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 @Getter
 public class UserGetResponse {
 
+    private final Long userId;
+
     private final String email;
 
     private final String nickname;
@@ -33,6 +35,7 @@ public class UserGetResponse {
     private final List<Category> categories;
 
     public UserGetResponse(User user, List<PreferenceCategory> categories) {
+        this.userId = user.getId();
         this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.ageGroup = user.getAgeGroup();


### PR DESCRIPTION
## 유저 정보 조회 API response에 userId 추가 <!-- 소셜 로그인 구현 -->

### 구현 내용
- 유저 정보 조회 API response에 userId 추가

### 예시
<img width="1359" alt="스크린샷 2022-10-29 오후 6 31 39" src="https://user-images.githubusercontent.com/53249897/198824358-cd0fffea-4c09-4e9d-b7fb-81af9d6e7a22.png">

```json
{
    "message": "나의 정보 조회가 성공하였습니다.",
    "data": {
        "userId": 8,
        "email": "a6@naver.com",
        "nickname": "a6",
        "ageGroup": "TWENTIES",
        "gender": "MALE",
        "job": "OFFICE_WORKERS",
        "categories": [
            "HOBBY",
            "SOCIAL_POLITICS",
            "LEARNING"
        ]
    }
}
```
