### PR TITLE
토큰 관리 리팩토링 (MOKA-134)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = 'com.mokaform'
-version = '0.0.14-SNAPSHOT-0.0.6-TEST'
+version = '0.0.13-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {

--- a/src/main/java/com/mokaform/mokaformserver/common/config/JwtConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/JwtConfig.java
@@ -1,11 +1,8 @@
 package com.mokaform.mokaformserver.common.config;
 
-import com.mokaform.mokaformserver.common.jwt.JwtAuthenticationFilter;
-import com.mokaform.mokaformserver.common.jwt.JwtService;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
 import java.text.MessageFormat;
@@ -40,8 +37,4 @@ public class JwtConfig {
                 .toString();
     }
 
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService) {
-        return new JwtAuthenticationFilter(this.accessTokenHeader, jwtService);
-    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://www.mokaform.site")
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .exposedHeaders("Authorization")
+                .exposedHeaders("Authorization", "Set-Cookie", "Access-Control-Allow-Origin", "Access-Control-Allow-Credentials")
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebConfig.java
@@ -20,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://www.mokaform.site")
                 .allowedMethods("*")
                 .allowedHeaders("*")
+                .exposedHeaders("Authorization")
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
@@ -1,10 +1,8 @@
 package com.mokaform.mokaformserver.common.config;
 
-import com.mokaform.mokaformserver.common.jwt.ExceptionHandlerFilter;
-import com.mokaform.mokaformserver.common.jwt.Jwt;
-import com.mokaform.mokaformserver.common.jwt.JwtAuthenticationFilter;
-import com.mokaform.mokaformserver.common.jwt.JwtAuthenticationProvider;
+import com.mokaform.mokaformserver.common.jwt.*;
 import com.mokaform.mokaformserver.common.util.RedisService;
+import com.mokaform.mokaformserver.user.domain.enums.RoleName;
 import com.mokaform.mokaformserver.user.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,11 +70,16 @@ public class WebSecurityConfig {
         return new Jwt(
                 jwtConfig.getIssuer(),
                 jwtConfig.getClientSecret(),
-//                jwtConfig.getAccessTokenHeader(),
-//                jwtConfig.getRefreshTokenHeader(),
+                jwtConfig.getAccessTokenHeader(),
+                jwtConfig.getRefreshTokenHeader(),
                 jwtConfig.getAccessTokenExpirySeconds(),
                 jwtConfig.getRefreshTokenExpirySeconds()
         );
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService) {
+        return new JwtAuthenticationFilter(jwtService);
     }
 
     @Bean

--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
@@ -105,6 +105,10 @@ public class WebSecurityConfig {
                                            JwtAuthenticationFilter jwtAuthenticationFilter,
                                            AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
         http.authorizeRequests()
+                .antMatchers("/api/v1/survey/list").permitAll()
+                .antMatchers("/api/v1/users/my/**",
+                        "/api/v1/survey/**",
+                        "/api/v1/answer/**").hasAnyAuthority(RoleName.USER.name())
                 .anyRequest().permitAll()
                 .and()
                 /**

--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsUtils;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -105,6 +106,7 @@ public class WebSecurityConfig {
                                            JwtAuthenticationFilter jwtAuthenticationFilter,
                                            AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
         http.authorizeRequests()
+                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/api/v1/survey/list").permitAll()
                 .antMatchers("/api/v1/users/my/**",
                         "/api/v1/survey/**",

--- a/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/CommonErrorCode.java
@@ -11,7 +11,9 @@ public enum CommonErrorCode implements ErrorCode {
     ILLEGAL_TOKEN("C006", HttpStatus.FORBIDDEN, "Illegal token"),
     LOGGED_OUT_ACCESS_TOKEN("C007", HttpStatus.BAD_REQUEST, "This access token has been logged out."),
     NOT_EXPIRED_ACCESS_TOKEN("C008", HttpStatus.BAD_REQUEST, "Access token is not expired"),
-    ILLEGAL_REFRESH_TOKEN("C009", HttpStatus.FORBIDDEN, "Illegal refresh token. Login required");
+    ILLEGAL_REFRESH_TOKEN("C009", HttpStatus.FORBIDDEN, "Illegal refresh token. Login required"),
+    ACCESS_TOKEN_NOT_EXIST("C010", HttpStatus.BAD_REQUEST, "Access token in header required."),
+    REFRESH_TOKEN_NOT_EXIST("C011", HttpStatus.BAD_REQUEST, "Refresh token in cookie required.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/Jwt.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/Jwt.java
@@ -19,6 +19,10 @@ public final class Jwt {
 
     private final String clientSecret;
 
+    private final String accessTokenHeader;
+
+    private final String refreshTokenHeader;
+
     private final int accessTokenExpirySeconds;
 
     private final int refreshTokenExpirySeconds;
@@ -27,9 +31,11 @@ public final class Jwt {
 
     private final JWTVerifier jwtVerifier;
 
-    public Jwt(String issuer, String clientSecret, int accessTokenExpirySeconds, int refreshTokenExpirySeconds) {
+    public Jwt(String issuer, String clientSecret, String accessTokenHeader, String refreshTokenHeader, int accessTokenExpirySeconds, int refreshTokenExpirySeconds) {
         this.issuer = issuer;
         this.clientSecret = clientSecret;
+        this.accessTokenHeader = accessTokenHeader;
+        this.refreshTokenHeader = refreshTokenHeader;
         this.accessTokenExpirySeconds = accessTokenExpirySeconds;
         this.refreshTokenExpirySeconds = refreshTokenExpirySeconds;
         this.algorithm = Algorithm.HMAC512(clientSecret);
@@ -74,6 +80,14 @@ public final class Jwt {
 
     public String getClientSecret() {
         return clientSecret;
+    }
+
+    public String getAccessTokenHeader() {
+        return accessTokenHeader;
+    }
+
+    public String getRefreshTokenHeader() {
+        return refreshTokenHeader;
     }
 
     public int getAccessTokenExpirySeconds() {

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtAuthenticationFilter.java
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
             getAccessToken(request).ifPresent(token -> {
-                if (!request.getRequestURI().contains("/token/reissue")) {
+                if (jwtService.isRequiredAuthorization(request.getRequestURI())) {
                     try {
                         Jwt.Claims claims = jwtService.verifyAccessToken(token);
                         log.debug("Jwt parse result: {}", claims);

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtAuthenticationFilter.java
@@ -29,13 +29,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final String accessHeaderKey;
-
     private final JwtService jwtService;
 
-    public JwtAuthenticationFilter(String accessHeaderKey,
-                                   JwtService jwtService) {
-        this.accessHeaderKey = accessHeaderKey;
+    public JwtAuthenticationFilter(JwtService jwtService) {
         this.jwtService = jwtService;
     }
 
@@ -81,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private Optional<String> getAccessToken(HttpServletRequest request) {
-        String token = request.getHeader(accessHeaderKey);
+        String token = getJwtFromRequest(request);
         if (isNotBlank(token)) {
             log.debug("Jwt access token detected: {}", token);
             try {
@@ -91,6 +87,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
         return Optional.empty();
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (isNotBlank(bearerToken)
+                && bearerToken.startsWith("Bearer")) {
+            log.debug("Bearer Token detected: {}", bearerToken);
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
     }
 
     private List<GrantedAuthority> getAuthorities(Jwt.Claims claims) {

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
@@ -20,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.net.URLDecoder;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Optional;
 
@@ -92,6 +93,19 @@ public class JwtService {
         if (values != null) {
             throw new AuthException(CommonErrorCode.LOGGED_OUT_ACCESS_TOKEN);
         }
+    }
+
+    public boolean isRequiredAuthorization(String requestURI) {
+        String[] notRequiredAuth = {
+                "/api/v1/users/signup",
+                "/api/v1/users/check-email-duplication",
+                "/api/v1/users/check-nickname-duplication",
+                "/api/v1/users/login",
+                "/api/v1/users/token/reissue",
+                "/api/v1/survey/list"
+        };
+
+        return !Arrays.asList(notRequiredAuth).contains(requestURI);
     }
 
     private void checkRefreshToken(String email, String refreshToken) {

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
@@ -71,12 +71,12 @@ public class JwtService {
         if (!jwt.isExpiredToken(accessToken)) {
             throw new ApiException(CommonErrorCode.NOT_EXPIRED_ACCESS_TOKEN);
         }
-        
+
         Cookie cookie = CookieUtils.getCookie(request, jwt.getRefreshTokenHeader())
                 .orElseThrow(() -> new ApiException(CommonErrorCode.REFRESH_TOKEN_NOT_EXIST));
         String refreshToken = cookie.getValue();
 
-        Jwt.Claims claims = getClaims(refreshToken);
+        Jwt.Claims claims = getClaims(accessToken);
         checkRefreshToken(claims.email, refreshToken);
         String newAccessToken = getNewAccessToken(claims.email, claims.roles);
         response.setHeader("Authorization", "Bearer " + newAccessToken);

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
@@ -8,17 +8,27 @@ import com.mokaform.mokaformserver.common.util.CookieUtils;
 import com.mokaform.mokaformserver.common.util.RedisService;
 import com.mokaform.mokaformserver.common.util.constant.RedisConstants;
 import com.mokaform.mokaformserver.user.dto.request.LocalLoginRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLDecoder;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.Date;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
 public class JwtService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final Jwt jwt;
 
@@ -33,10 +43,7 @@ public class JwtService {
     }
 
     public Jwt.Claims verifyAccessToken(String accessToken) {
-        String values = redisService.getValues(RedisConstants.LOGOUT.getPrefix() + accessToken);
-        if (values != null) {
-            throw new AuthException(CommonErrorCode.LOGGED_OUT_ACCESS_TOKEN);
-        }
+        checkLoggedOut(accessToken);
 
         return verify(accessToken);
     }
@@ -58,14 +65,33 @@ public class JwtService {
         redisService.setValues(RedisConstants.LOGOUT.getPrefix() + token, token, Duration.ofMillis(remainingExpirySeconds));
     }
 
-    public String reissueAccessToken(String accessToken, String refreshToken) {
+    public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        String accessToken = getAccessToken(request)
+                .orElseThrow(() -> new ApiException(CommonErrorCode.ACCESS_TOKEN_NOT_EXIST));
         if (!jwt.isExpiredToken(accessToken)) {
             throw new ApiException(CommonErrorCode.NOT_EXPIRED_ACCESS_TOKEN);
         }
+        
+        Cookie cookie = CookieUtils.getCookie(request, jwt.getRefreshTokenHeader())
+                .orElseThrow(() -> new ApiException(CommonErrorCode.REFRESH_TOKEN_NOT_EXIST));
+        String refreshToken = cookie.getValue();
 
-        Jwt.Claims claims = getClaims(accessToken);
+        Jwt.Claims claims = getClaims(refreshToken);
         checkRefreshToken(claims.email, refreshToken);
-        return getAccessToken(claims.email, claims.roles);
+        String newAccessToken = getNewAccessToken(claims.email, claims.roles);
+        response.setHeader("Authorization", "Bearer " + newAccessToken);
+    }
+
+    public Jwt.Claims getAccessTokenClaims(String accessToken) {
+        checkLoggedOut(accessToken);
+        return getClaims(accessToken);
+    }
+
+    public void checkLoggedOut(String accessToken) {
+        String values = redisService.getValues(RedisConstants.LOGOUT.getPrefix() + accessToken);
+        if (values != null) {
+            throw new AuthException(CommonErrorCode.LOGGED_OUT_ACCESS_TOKEN);
+        }
     }
 
     private void checkRefreshToken(String email, String refreshToken) {
@@ -76,16 +102,39 @@ public class JwtService {
         }
     }
 
-    private String getAccessToken(String email, String[] roles) {
+    private String getNewAccessToken(String email, String[] roles) {
         return jwt.signAccessToken(Jwt.Claims.from(email, roles));
     }
 
-    private Jwt.Claims getClaims(String accessToken) {
-        DecodedJWT decodedJWT = com.auth0.jwt.JWT.decode(accessToken);
+    private Jwt.Claims getClaims(String token) {
+        DecodedJWT decodedJWT = com.auth0.jwt.JWT.decode(token);
         return new Jwt.Claims(decodedJWT);
     }
 
     private Jwt.Claims verify(String token) {
         return jwt.verify(token);
+    }
+
+    private Optional<String> getAccessToken(HttpServletRequest request) {
+        String token = getJwtFromRequest(request);
+        if (isNotBlank(token)) {
+            log.debug("Jwt access token detected: {}", token);
+            try {
+                return Optional.of(URLDecoder.decode(token, "UTF-8"));
+            } catch (Exception e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (isNotBlank(bearerToken)
+                && bearerToken.startsWith("Bearer")) {
+            log.debug("Bearer Token detected: {}", bearerToken);
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/common/util/CookieUtils.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/util/CookieUtils.java
@@ -1,0 +1,70 @@
+package com.mokaform.mokaformserver.common.util;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.SerializationUtils;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CookieUtils {
+
+    public static void addJWTToCookie(HttpServletResponse response, String name, String token) {
+        DecodedJWT decodedJWT = com.auth0.jwt.JWT.decode(token);
+        int maxAge = Long.valueOf(TimeUnit.MILLISECONDS.toSeconds(decodedJWT.getExpiresAt().getTime() - new Date().getTime())).intValue();
+        addCookie(response, name, token, maxAge);
+    }
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0)
+            return Optional.empty();
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> StringUtils.equals(cookie.getName(), name))
+                .findAny();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0)
+            return;
+
+        Arrays.stream(cookies)
+                .filter(cookie -> StringUtils.equals(cookie.getName(), name))
+                .forEach(cookie -> {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                });
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> clazz) {
+        return clazz.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -12,7 +12,6 @@ import com.mokaform.mokaformserver.survey.dto.response.SurveyInfoResponse;
 import com.mokaform.mokaformserver.survey.service.SurveyService;
 import com.mokaform.mokaformserver.user.dto.request.LocalLoginRequest;
 import com.mokaform.mokaformserver.user.dto.request.SignupRequest;
-import com.mokaform.mokaformserver.user.dto.request.TokenReissueRequest;
 import com.mokaform.mokaformserver.user.dto.response.DuplicateValidationResponse;
 import com.mokaform.mokaformserver.user.dto.response.LocalLoginResponse;
 import com.mokaform.mokaformserver.user.dto.response.UserGetResponse;
@@ -26,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
@@ -192,12 +192,12 @@ public class UserController {
 
     @Operation(summary = "토큰 재발급", description = "access token을 재발급하는 API입니다.")
     @PostMapping("/token/reissue")
-    public ResponseEntity<ApiResponse> reissueAccessToken(@RequestBody @Valid TokenReissueRequest request) {
-        String newAccessToken = jwtService.reissueAccessToken(request.getAccessToken(), request.getRefreshToken());
+    public ResponseEntity<ApiResponse> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        jwtService.reissueAccessToken(request, response);
+
         return ResponseEntity.ok()
                 .body(ApiResponse.builder()
                         .message("토큰이 재발급되었습니다.")
-                        .data(newAccessToken)
                         .build());
     }
 }


### PR DESCRIPTION
## 토큰 관리 리팩토링

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-134

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 로그인 API response 변경
  - Access token
    - Header의 Authorization에 Bearer로 토큰값을 줌
  - Refresh token
    - cookie에 'refreshToken'으로 토큰값을 줌
<img width="1359" alt="스크린샷 2022-11-06 오후 9 51 13" src="https://user-images.githubusercontent.com/53249897/200171777-914178dd-467b-420c-b234-3477e0d26d61.png">

```
 authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyb2xlcyI6WyJVU0VSIl0sImlzcyI6InRlc3QiLCJleHAiOjE2Njc3Mzg5ODIsImlhdCI6MTY2NzczODg5MiwiZW1haWwiOiJlbWlseUBnbWFpbC5jb20ifQ.gSUJITr5SFDYJ3-cNqoNerdu3v8HBfdDjMFHd1tv6HF8ghMviECem1uedfPn_oro58gUJzoFfhAXiOzIUVtJtA 
 connection: keep-alive 
 content-type: application/json 
 date: Sun,06 Nov 2022 12:48:13 GMT 
 keep-alive: timeout=60 
 transfer-encoding: chunked 
 vary: Origin,Access-Control-Request-Method,Access-Control-Request-Headers 
``` 
### 리뷰 포인트
- [ ] 클라이언트에서 구현된 요청/응답과 맞는지 확인 필요

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 클라이언트와 테스트 완료 후에 머지할 계획입니다.
- [ ] swagger 'authorize' 버튼 설정 수정
- [ ] refresh token claim 수정