### PR TITLE
Swagger 토큰 테스트 방식 변경 (MOKA-142)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/SwaggerConfig.java
@@ -15,27 +15,37 @@ public class SwaggerConfig {
     public OpenAPI openAPI(@Value("${springdoc.version}") String appVersion) {
         Info info = new Info().title("Demo API").version(appVersion)
                 .description("Team MOKA의 mokaform 웹 애플리케이션 API입니다.\n" +
-                        "로그인 요청 후에 응답으로 온 accessToken을 오른쪽 Authorize 버튼을 누르고 입력한 후에 API 요청을 보내면" +
-                        " 인가가 필요한 요청에 대한 응답을 받을 수 있습니다.");
+                        "로그인 요청 후에 응답 헤더(authorization: Bearer ${ACCESS_TOKE})으로 온 accessToken을 오른쪽 Authorize 버튼을 누르고 입력한 후에 API 요청을 보내면" +
+                        " 인가가 필요한 요청에 대한 응답을 받을 수 있습니다. 브라우저 보안 정책으로 인해 쿠키 인증은 불가능하여 '토큰 재발행'API는 swagger에서 테스트 불가능합니다.");
 
         return new OpenAPI()
-                .components(new Components().addSecuritySchemes("JWT", getAuthScheme()))
+                .components(new Components()
+                        .addSecuritySchemes("Access Token", getAccessTokenAuthScheme())
+                        .addSecuritySchemes("Refresh Token", getRefreshTokenAuthScheme()))
                 .addSecurityItem(getSecurityItem())
                 .info(info);
     }
 
-    private SecurityScheme getAuthScheme() {
+    private SecurityScheme getAccessTokenAuthScheme() {
         return new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
+                .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
                 .bearerFormat("JWT")
                 .in(SecurityScheme.In.HEADER)
-                .name("accessToken");
+                .name("Authorization");
+    }
+
+    private SecurityScheme getRefreshTokenAuthScheme() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("refreshToken");
     }
 
     private SecurityRequirement getSecurityItem() {
         SecurityRequirement securityItem = new SecurityRequirement();
-        securityItem.addList("JWT");
+        securityItem.addList("Access Token");
+        securityItem.addList("Refresh Token");
         return securityItem;
     }
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -18,6 +18,9 @@ import com.mokaform.mokaformserver.user.dto.response.UserGetResponse;
 import com.mokaform.mokaformserver.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -153,6 +156,14 @@ public class UserController {
     }
 
     @Operation(summary = "로그인", description = "로그인하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+                    headers = @Header(
+                            name = "Set-Cookie",
+                            schema = @Schema(
+                                    type = "String",
+                                    example = "refreshToken=${REFRESH_TOKEN}; Max-Age=1209599; Expires=Tue, 22-Nov-2022 09:07:55 GMT; Path=/; Secure; HttpOnly")))
+    })
     @PostMapping(path = "/login")
     public ResponseEntity<ApiResponse<LocalLoginResponse>> login(@RequestBody @Valid LocalLoginRequest request,
                                                                  HttpServletResponse response) {


### PR DESCRIPTION
## Swagger 토큰 테스트 방식 변경

### 지라 티켓 번호
<!-- MOKA-xxxx -->
MOKA-142

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- 토근 관리 방식이 수정되어 swagger에서 테스트해 볼 수 있도록 수정
- Access token
  - 로그인 후에 응답 헤더에서 access token을 복사하여 오른쪽 위의 Authorize 버튼을 누르고 Access Token에 넣음
  - 그러면 모든 요청 헤더에 `Authorization: Bearer ${ACCESS_TOKEN}이 들어감
  - 참고: https://swagger.io/docs/specification/authentication/bearer-authentication/
- Refresh token
  - 브라우저에서는 보안 때문에 쿠키를 확인할 수 없음 -> refresh token을 확인할 수 없어서 "토큰 재발행" API는 swagger에서 테스트 불가능
  - 포스트맨으로 테스트하는 방법
    - 포스트맨에서 로그인 API를 요청하고 응답 헤더에서 Cookie의 값을 swagger의 `Authorize 버튼 > Refresh Token`을 넣어서 테스트 가능
  - 참고: https://swagger.io/docs/specification/authentication/cookie-authentication/
  - 참고: https://github.com/swagger-api/swagger-js/issues/1163
