### PR TITLE
[HOT!] 비밀번호 재설정 - 인증번호 전송 API에 validation 추가

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/user/service/EmailService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/EmailService.java
@@ -5,6 +5,7 @@ import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
 import com.mokaform.mokaformserver.common.exception.errorcode.UserErrorCode;
 import com.mokaform.mokaformserver.common.util.RedisService;
+import com.mokaform.mokaformserver.common.util.UserUtilService;
 import com.mokaform.mokaformserver.common.util.constant.EmailType;
 import com.mokaform.mokaformserver.common.util.constant.RedisConstants;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -34,12 +35,16 @@ public class EmailService {
 
     private final RedisService redisService;
 
+    private final UserUtilService userUtilService;
+
     public EmailService(MailConfig mailConfig,
                         JavaMailSender javaMailSender,
-                        RedisService redisService) {
+                        RedisService redisService,
+                        UserUtilService userUtilService) {
         this.mailConfig = mailConfig;
         this.javaMailSender = javaMailSender;
         this.redisService = redisService;
+        this.userUtilService = userUtilService;
         this.verificationCode = RandomStringUtils.random(6, true, true);
     }
 
@@ -50,6 +55,10 @@ public class EmailService {
         bean으로 등록해둔 javaMailSender 객체를 사용하여 이메일 send
      */
     public void sendVerificationCode(EmailType type, String email) {
+        if (type.equals(EmailType.RESET_PASSWORD)) {
+            userUtilService.checkUser(email);
+        }
+        
         try {
             MimeMessage message = createMessage(type.getSubject(), email);
             javaMailSender.send(message); // 메일 발송


### PR DESCRIPTION
## 비밀번호 재설정 - 인증번호 전송 API에 validation 추가

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
- url: `/api/v1/users/reset-password/email-verification/send?email=` (url 변경 없음)
- 인증번호 전송에서 비밀번호 재설정인 경우에는 존재하는 유저의 email인지 확인
- 존재하지 않는 유저인 경우에 U001 (404 Not Found) 발생

```json
{
    "code": "U001",
    "message": "User not found"
}
```