### PR TITLE
카테고리별 추천 설문 목록 조회 API (MOKA-152)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/config/WebSecurityConfig.java
@@ -107,7 +107,8 @@ public class WebSecurityConfig {
                                            AuthenticationEntryPoint authenticationEntryPoint) throws Exception {
         http.authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                .antMatchers("/api/v1/survey/list").permitAll()
+                .antMatchers("/api/v1/survey/list",
+                        "/api/v1/survey/recommended-list").permitAll()
                 .antMatchers("/api/v1/users/my/**",
                         "/api/v1/survey/**",
                         "/api/v1/answer/**").hasAnyAuthority(RoleName.USER.name())

--- a/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/SurveyErrorCode.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/exception/errorcode/SurveyErrorCode.java
@@ -10,7 +10,8 @@ public enum SurveyErrorCode implements ErrorCode {
     NO_PERMISSION_TO_GET_SURVEY_INFO("S004", HttpStatus.NOT_FOUND, "설문 정보를 얻을 수 없습니다."),
     NO_PERMISSION_TO_UPDATE_SURVEY("S005", HttpStatus.NOT_FOUND, "설문을 수정할 수 없습니다."),
     INVALID_START_DATE("S006", HttpStatus.BAD_REQUEST, "설문 시작일은 오늘 이전일 수 없습니다."),
-    INVALID_END_DATE("S007", HttpStatus.BAD_REQUEST, "설문 종료일은 시작일 이전일 수 없습니다.");
+    INVALID_END_DATE("S007", HttpStatus.BAD_REQUEST, "설문 종료일은 시작일 이전일 수 없습니다."),
+    INVALID_CATEGORY_TYPE("S008", HttpStatus.BAD_REQUEST, "잘못된 카테고리 종류입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/jwt/JwtService.java
@@ -107,7 +107,8 @@ public class JwtService {
                 "/api/v1/users/reset-password/email-verification/send",
                 "/api/v1/users/reset-password/email-verification/check",
                 "/api/v1/users/reset-password",
-                "/api/v1/survey/list"
+                "/api/v1/survey/list",
+                "/api/v1/survey/recommended-list"
         };
 
         return !Arrays.asList(notRequiredAuth).contains(requestURI);

--- a/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
@@ -90,6 +90,20 @@ public class SurveyController {
                 .body(apiResponse);
     }
 
+    @GetMapping("/recommended-list")
+    public ResponseEntity<ApiResponse<SurveyInfoResponse>> getRecommendedSurveyInfos(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
+                                                                                     @RequestParam(value = "category") String category) {
+        PageResponse<SurveyInfoResponse> response = surveyService.getRecommendedSurveyInfos(pageable, category);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .message("카테고리별 추천 설문 다건 조회가 성공하였습니다.")
+                .data(response)
+                .build();
+
+        return ResponseEntity.ok()
+                .body(apiResponse);
+    }
+
     @Operation(summary = "설문 삭제", description = "설문을 삭제하는 API입니다.")
     @DeleteMapping("/{surveyId}")
     public ResponseEntity<ApiResponse<SurveyDeleteResponse>> removeSurvey(@PathVariable(value = "surveyId") Long surveyId,

--- a/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/controller/SurveyController.java
@@ -90,8 +90,11 @@ public class SurveyController {
                 .body(apiResponse);
     }
 
+    @Operation(summary = "카테고리별 추천 설문 다건 조회", description = "카테고리별 추천 설문을 다건 조회하는 API입니다.")
     @GetMapping("/recommended-list")
-    public ResponseEntity<ApiResponse<SurveyInfoResponse>> getRecommendedSurveyInfos(@PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
+    public ResponseEntity<ApiResponse<SurveyInfoResponse>> getRecommendedSurveyInfos(@Parameter(description = "sort: {createdAt, surveyeeCount}, {asc, desc} 가능 => 예시: \"createdAt,desc\"")
+                                                                                     @PageableDefault(sort = "createdAt", direction = DESC) Pageable pageable,
+                                                                                     @Parameter(description = "DAILY_LIFE, IT, HOBBY, LEARNING, PSYCHOLOGY, SOCIAL_POLITICS, PREFERENCE_RESEARCH, PET")
                                                                                      @RequestParam(value = "category") String category) {
         PageResponse<SurveyInfoResponse> response = surveyService.getRecommendedSurveyInfos(pageable, category);
 

--- a/src/main/java/com/mokaform/mokaformserver/survey/domain/enums/Category.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/domain/enums/Category.java
@@ -1,5 +1,10 @@
 package com.mokaform.mokaformserver.survey.domain.enums;
 
+import com.mokaform.mokaformserver.common.exception.ApiException;
+import com.mokaform.mokaformserver.common.exception.errorcode.SurveyErrorCode;
+
+import java.util.Arrays;
+
 public enum Category {
     DAILY_LIFE,             // 일상
     IT,                     // IT
@@ -8,5 +13,12 @@ public enum Category {
     PSYCHOLOGY,             // 취미
     SOCIAL_POLITICS,        // 사회/정치
     PREFERENCE_RESEARCH,     // 선호도 조사
-    PET                     // 반려동물
+    PET;                     // 반려동물
+
+    public static Category getCategory(String categoryName) {
+        return Arrays.stream(Category.values())
+                .filter(type -> type.name().equals(categoryName))
+                .findAny()
+                .orElseThrow(() -> new ApiException(SurveyErrorCode.INVALID_CATEGORY_TYPE));
+    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyCustomRepository.java
@@ -1,5 +1,6 @@
 package com.mokaform.mokaformserver.survey.repository;
 
+import com.mokaform.mokaformserver.survey.domain.enums.Category;
 import com.mokaform.mokaformserver.survey.dto.mapping.SubmittedSurveyInfoMapping;
 import com.mokaform.mokaformserver.survey.dto.mapping.SurveyInfoMapping;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 public interface SurveyCustomRepository {
 
     Page<SurveyInfoMapping> findSurveyInfos(Pageable pageable, Long userId);
+
+    Page<SurveyInfoMapping> findRecommendedSurveyInfos(Pageable pageable, Category category);
 
     Page<SubmittedSurveyInfoMapping> findSubmittedSurveyInfos(Pageable pageable, Long userId);
 

--- a/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/service/SurveyService.java
@@ -128,6 +128,14 @@ public class SurveyService {
     }
 
     @Transactional(readOnly = true)
+    public PageResponse<SurveyInfoResponse> getRecommendedSurveyInfos(Pageable pageable, String categoryName) {
+        Page<SurveyInfoMapping> surveyInfos = surveyRepository.findRecommendedSurveyInfos(pageable, Category.getCategory(categoryName));
+        return new PageResponse<>(
+                surveyInfos.map(surveyInfo ->
+                        new SurveyInfoResponse(surveyInfo, getSurveyCategories(surveyInfo.getSurveyId()))));
+    }
+
+    @Transactional(readOnly = true)
     public PageResponse<SubmittedSurveyInfoResponse> getSubmittedSurveyInfos(Pageable pageable, String userEmail) {
         User user = userUtilService.getUser(userEmail);
         Page<SubmittedSurveyInfoMapping> surveyInfos = surveyRepository.findSubmittedSurveyInfos(pageable, user.getId());


### PR DESCRIPTION
## 카테고리별 추천 설문 목록 조회 API

### 지라 티켓 번호
MOKA-152

### 구현 내용
- 카테고리별 추천 설문 다건 조회 API 구현
- query param으로 카데고리를 넣으면 해당 카데고리가 포함된 설문 목록을 조회할 수 있음
- 카테고리 종류: DAILY_LIFE, IT, HOBBY, LEARNING, PSYCHOLOGY, SOCIAL_POLITICS, PREFERENCE_RESEARCH, PET

### 요청/응답 예시
**request**
- url: `http://localhost:8080/api/v1/survey/recommended-list?category=&page=0&size=&sort=`
- query param
  - (필수) category: 카테고리 종류
  - (옵션) page, size, sort
 
**response**
<img width="1359" alt="스크린샷 2022-11-17 오후 8 05 57" src="https://user-images.githubusercontent.com/53249897/202430235-159d56a2-3293-432b-be44-65822dcd2192.png">

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 테스트 코드 작성