### PR TITLE
회원 탈퇴 API 구현 (MOKA-154)

### DIFF
--- a/src/main/java/com/mokaform/mokaformserver/common/util/UserUtilService.java
+++ b/src/main/java/com/mokaform/mokaformserver/common/util/UserUtilService.java
@@ -18,7 +18,7 @@ public class UserUtilService {
 
     @Transactional(readOnly = true)
     public User getUser(String email) {
-        return userRepository.findByEmail(email)
+        return userRepository.findByEmailAndIsWithdraw(email, false)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/survey/repository/SurveyRepository.java
@@ -3,9 +3,12 @@ package com.mokaform.mokaformserver.survey.repository;
 import com.mokaform.mokaformserver.survey.domain.Survey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long>, SurveyCustomRepository {
 
     Optional<Survey> findBySharingKey(String sharingKey);
+
+    List<Survey> findAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -275,8 +275,9 @@ public class UserController {
                         .build());
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴하는 API입니다.")
     @PostMapping("/withdrawal")
-    public ResponseEntity<ApiResponse> withdraw(@AuthenticationPrincipal JwtAuthentication authentication) {
+    public ResponseEntity<ApiResponse> withdraw(@Parameter(hidden = true) @AuthenticationPrincipal JwtAuthentication authentication) {
         userService.withdraw(authentication.email);
 
         return ResponseEntity.ok()

--- a/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/controller/UserController.java
@@ -274,4 +274,14 @@ public class UserController {
                         .message("비밀번호 재설정이 완료되었습니다.")
                         .build());
     }
+
+    @PostMapping("/withdrawal")
+    public ResponseEntity<ApiResponse> withdraw(@AuthenticationPrincipal JwtAuthentication authentication) {
+        userService.withdraw(authentication.email);
+
+        return ResponseEntity.ok()
+                .body(ApiResponse.builder()
+                        .message("회원 탈퇴가 완료되었습니다.")
+                        .build());
+    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/domain/User.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/domain/User.java
@@ -102,4 +102,9 @@ public class User extends BaseEntity {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void withdraw() {
+        this.isWithdraw = true;
+        this.withdrawAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
@@ -9,8 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByEmailAndPassword(String email, String password);
-
     Boolean existsByEmail(String email);
 
     Boolean existsByNickname(String nickname);

--- a/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/repository/UserRepository.java
@@ -9,6 +9,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByEmailAndIsWithdraw(String email, Boolean isWithdraw);
+
     Boolean existsByEmail(String email);
 
     Boolean existsByNickname(String nickname);

--- a/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
+++ b/src/main/java/com/mokaform/mokaformserver/user/service/UserService.java
@@ -3,7 +3,9 @@ package com.mokaform.mokaformserver.user.service;
 import com.mokaform.mokaformserver.common.exception.ApiException;
 import com.mokaform.mokaformserver.common.exception.errorcode.CommonErrorCode;
 import com.mokaform.mokaformserver.common.exception.errorcode.UserErrorCode;
+import com.mokaform.mokaformserver.survey.domain.Survey;
 import com.mokaform.mokaformserver.survey.domain.enums.Category;
+import com.mokaform.mokaformserver.survey.repository.SurveyRepository;
 import com.mokaform.mokaformserver.user.domain.PreferenceCategory;
 import com.mokaform.mokaformserver.user.domain.Role;
 import com.mokaform.mokaformserver.user.domain.User;
@@ -35,13 +37,18 @@ public class UserService {
     private final PreferenceCategoryRepository preferenceCategoryRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SurveyRepository surveyRepository;
 
-    public UserService(UserRepository userRepository, PreferenceCategoryRepository preferenceCategoryRepository,
-                       RoleRepository roleRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository,
+                       PreferenceCategoryRepository preferenceCategoryRepository,
+                       RoleRepository roleRepository,
+                       PasswordEncoder passwordEncoder,
+                       SurveyRepository surveyRepository) {
         this.userRepository = userRepository;
         this.preferenceCategoryRepository = preferenceCategoryRepository;
         this.roleRepository = roleRepository;
         this.passwordEncoder = passwordEncoder;
+        this.surveyRepository = surveyRepository;
     }
 
     @Transactional
@@ -86,7 +93,7 @@ public class UserService {
         Assert.isTrue(isNotEmpty(principal), "principal must be provided.");
         Assert.isTrue(isNotEmpty(credentials), "credentials must be provided.");
 
-        User user = userRepository.findByEmail(principal)
+        User user = userRepository.findByEmailAndIsWithdraw(principal, false)
                 .orElseThrow(() -> new UsernameNotFoundException("Could not found user for " + principal));
         user.checkPassword(passwordEncoder, credentials);
         return user;
@@ -94,7 +101,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserGetResponse getUserInfo(String userEmail) {
-        User user = userRepository.findByEmail(userEmail)
+        User user = userRepository.findByEmailAndIsWithdraw(userEmail, false)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
         List<PreferenceCategory> preferenceCategories = preferenceCategoryRepository.findByUserId(user.getId());
 
@@ -103,9 +110,18 @@ public class UserService {
 
     @Transactional
     public void updatePassword(ResetPasswordRequest request) {
-        User user = userRepository.findByEmail(request.getEmail())
+        User user = userRepository.findByEmailAndIsWithdraw(request.getEmail(), false)
                 .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
         user.updatePassword(passwordEncoder.encode(request.getPassword()));
     }
 
+    @Transactional
+    public void withdraw(String userEmail) {
+        User user = userRepository.findByEmailAndIsWithdraw(userEmail, false)
+                .orElseThrow(() -> new ApiException(UserErrorCode.USER_NOT_FOUND));
+        user.withdraw();
+
+        List<Survey> surveys = surveyRepository.findAllByUser_Id(user.getId());
+        surveys.forEach(s -> s.updateIsDeleted(true));
+    }
 }


### PR DESCRIPTION
## 회원 탈퇴 API 구현

### 지라 티켓 번호
MOKA-154

### 구현 내용
- 회원 탈퇴 기능 구현
- 데이터 분석을 위한 데이터 수집 목적으로 soft delete
- 회원 탈퇴 시
  - users table의 isWithdraw = true, withdrawAt=now()로 업데이트
  - 해당 유저가 작성한 설문 모두 isDeleted=true로 업데이트

### 요청 예시
**request**
- url: `http://localhost:8080/api/v1/users/withdrawal`
<img width="1359" alt="스크린샷 2022-11-17 오후 8 52 51" src="https://user-images.githubusercontent.com/53249897/202439363-965c2609-85c6-4a07-ab4d-bf9224a081ab.png">

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
- [ ] 테스트 코드